### PR TITLE
refactor!: Reduce Repr::new_unchecked escape hatches

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter, Result, Write};
 
 use crate::document::Document;
+use crate::key::Key;
 use crate::repr::{DecorDisplay, Formatted, Repr};
 use crate::{Array, InlineTable, Item, Table, Value};
 
@@ -23,6 +24,12 @@ impl Display for Repr {
 impl<T> Display for Formatted<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", self.decor.display(&self.repr))
+    }
+}
+
+impl Display for Key {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        self.repr().fmt(f)
     }
 }
 

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -67,10 +67,10 @@ impl InlineTable {
     /// Inserts a key/value pair if the table does not contain the key.
     /// Returns a mutable reference to the corresponding value.
     pub fn get_or_insert<V: Into<Value>>(&mut self, key: &str, value: V) -> &mut Value {
-        let parsed = key.parse::<Key>().expect("invalid key");
+        let key = Key::with_key(key);
         self.items
-            .entry(parsed.get().to_owned())
-            .or_insert(to_key_value(key, value.into()))
+            .entry(key.get().to_owned())
+            .or_insert(to_key_value(key.into_repr(), value.into()))
             .value
             .as_value_mut()
             .expect("non-value type in inline table")
@@ -155,15 +155,15 @@ where
 {
     let v = iter.into_iter().map(|(a, b)| {
         let s: &Key = a.into();
-        (s.get().into(), to_key_value(s.raw(), b.into()))
+        (s.get().into(), to_key_value(s.repr().to_owned(), b.into()))
     });
     v.collect()
 }
 
-pub fn to_key_value(key: &str, mut value: Value) -> TableKeyValue {
+pub fn to_key_value(key_repr: Repr, mut value: Value) -> TableKeyValue {
     value.decorate(" ", "");
     TableKeyValue {
-        key_repr: Repr::new_unchecked(key),
+        key_repr,
         key_decor: default_key_decor(),
         value: Item::Value(value),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,6 @@ pub use crate::inline_table::InlineTable;
 pub use crate::item::{array, table, value, Item};
 pub use crate::key::Key;
 pub use crate::parser::TomlError;
-pub use crate::repr::Decor;
+pub use crate::repr::{Decor, Repr};
 pub use crate::table::{Iter, IterMut, Table, TableLike};
 pub use crate::value::Value;

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -35,21 +35,21 @@ impl<T> Formatted<T> {
     }
 }
 
-// String representation of a key or a value
-// together with a decoration.
+/// TOML-encoded value
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Hash)]
-pub(crate) struct Repr {
+pub struct Repr {
     raw_value: InternalString,
 }
 
 impl Repr {
-    pub fn new_unchecked(raw: impl Into<InternalString>) -> Self {
+    pub(crate) fn new_unchecked(raw: impl Into<InternalString>) -> Self {
         Repr {
             raw_value: raw.into(),
         }
     }
 
-    pub(crate) fn as_raw(&self) -> &str {
+    /// Access the underlying value
+    pub fn as_raw(&self) -> &str {
         &self.raw_value
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -123,15 +123,29 @@ impl Table {
     /// To insert to table, use `entry` to return a mutable reference
     /// and set it to the appropriate value.
     pub fn entry<'a>(&'a mut self, key: &str) -> &'a mut Item {
-        let parsed_key = key.parse::<Key>().expect("invalid key");
+        let key = Key::with_key(key);
         &mut self
             .items
-            .entry(parsed_key.get().to_owned())
-            .or_insert(TableKeyValue::new(
-                Repr::new_unchecked(parsed_key.raw()),
-                default_key_decor(),
-                Item::None,
-            ))
+            .entry(key.get().to_owned())
+            .or_insert_with(|| {
+                TableKeyValue::new(key.repr().to_owned(), default_key_decor(), Item::None)
+            })
+            .value
+    }
+
+    /// Given the `key`, return a mutable reference to the value.
+    /// If there is no entry associated with the given key in the table,
+    /// a `Item::None` value will be inserted.
+    ///
+    /// To insert to table, use `entry` to return a mutable reference
+    /// and set it to the appropriate value.
+    pub fn entry_format<'a>(&'a mut self, key: &Key) -> &'a mut Item {
+        &mut self
+            .items
+            .entry(key.get().to_owned())
+            .or_insert_with(|| {
+                TableKeyValue::new(key.repr().to_owned(), default_key_decor(), Item::None)
+            })
             .value
     }
 

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -204,13 +204,13 @@ fn test_insert_values() {
         [tbl.son]"#
     ).running(|root| {
         root["tbl"]["key1"] = value("value1");
-        root["tbl"]["\"key2\""] = value(42);
-        root["tbl"]["'key3'"] = value(8.1415926);
+        root["tbl"]["key2"] = value(42);
+        root["tbl"]["key3"] = value(8.1415926);
     }).produces(r#"
 [tbl]
 key1 = "value1"
-"key2" = 42
-'key3' = 8.1415926
+key2 = 42
+key3 = 8.1415926
 
         [tbl.son]
 "#
@@ -622,12 +622,12 @@ fn test_insert_into_inline_table() {
         let b = root.entry("b");
         let b = as_inline_table!(b);
         assert!(b.is_empty());
-        b.get_or_insert("'hello'", "world");
+        b.get_or_insert("hello", "world");
         assert_eq!(b.len(), 1);
         b.fmt()
     }).produces(r#"
         a = { a = 2, c = 3, b = 42 }
-        b = { 'hello' = "world" }
+        b = { hello = "world" }
 "#
     );
 }


### PR DESCRIPTION
To help ensure we don't mix up what we are deaing with, this involves an
audit of `Repr::new_unchecked` and tries to move the calls to it closer
to where validation happens.

As part of this, this removes the "magic" of table keys being either
Rust strings or toml keys.

BREAKING CHANGE: Can no longer use TOML keys when mucking with tables.