### PR TITLE
fix: Allow dotted-inline-tables in stanard-tables

### DIFF
--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -44,11 +44,11 @@ impl InlineTable {
     pub fn get_values(&self) -> Vec<(Vec<&Key>, &Value)> {
         let mut values = Vec::new();
         let root = Vec::new();
-        self.get_values_internal(&root, &mut values);
+        self.append_values(&root, &mut values);
         values
     }
 
-    fn get_values_internal<'s, 'c>(
+    pub(crate) fn append_values<'s, 'c>(
         &'s self,
         parent: &[&'s Key],
         values: &'c mut Vec<(Vec<&'s Key>, &'s Value)>,
@@ -58,7 +58,7 @@ impl InlineTable {
             path.push(&value.key);
             match &value.value {
                 Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
-                    table.get_values_internal(&path, values);
+                    table.append_values(&path, values);
                 }
                 Item::Value(value) => {
                     values.push((path, value));

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -754,3 +754,44 @@ fn test_inline_table_append() {
     assert!(a.contains_key("e"));
     assert_eq!(b.len(), 3);
 }
+
+#[test]
+fn test_insert_dotted_into_std_table() {
+    given("")
+        .running(|root| {
+            root["nixpkgs"] = table();
+
+            root["nixpkgs"]["src"] = table();
+            root["nixpkgs"]["src"]
+                .as_table_mut()
+                .unwrap()
+                .set_dotted(true);
+            root["nixpkgs"]["src"]["git"] = value("https://github.com/nixos/nixpkgs");
+        })
+        .produces_display(
+            r#"
+[nixpkgs]
+src.git = "https://github.com/nixos/nixpkgs"
+"#,
+        );
+}
+
+#[test]
+fn test_insert_dotted_into_implicit_table() {
+    given("")
+        .running(|root| {
+            root["nixpkgs"] = table();
+
+            root["nixpkgs"]["src"]["git"] = value("https://github.com/nixos/nixpkgs");
+            root["nixpkgs"]["src"]
+                .as_inline_table_mut()
+                .unwrap()
+                .set_dotted(true);
+        })
+        .produces_display(
+            r#"
+[nixpkgs]
+src.git = "https://github.com/nixos/nixpkgs"
+"#,
+        );
+}


### PR DESCRIPTION
Before, we ignored the dotted-ness of it

Fixes #233