### PR TITLE
feat: Allow dotting on table-like

### DIFF
--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -388,6 +388,13 @@ impl TableLike for InlineTable {
     fn sort_values(&mut self) {
         self.sort_values()
     }
+    fn set_dotted(&mut self, yes: bool) {
+        self.set_dotted(yes)
+    }
+    fn is_dotted(&self) -> bool {
+        self.is_dotted()
+    }
+
     fn key_decor_mut(&mut self, key: &str) -> Option<&mut Decor> {
         self.key_decor_mut(key)
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -431,6 +431,10 @@ pub trait TableLike: crate::private::Sealed {
     ///
     /// Doesn't affect subtables or subarrays.
     fn sort_values(&mut self);
+    /// Change this table's dotted status
+    fn set_dotted(&mut self, yes: bool);
+    /// Check if this is a wrapper for dotted keys, rather than a standard table
+    fn is_dotted(&self) -> bool;
 
     /// Returns the decor associated with a given key of the table.
     fn key_decor_mut(&mut self, key: &str) -> Option<&mut Decor>;
@@ -470,6 +474,13 @@ impl TableLike for Table {
     fn sort_values(&mut self) {
         self.sort_values()
     }
+    fn is_dotted(&self) -> bool {
+        self.is_dotted()
+    }
+    fn set_dotted(&mut self, yes: bool) {
+        self.set_dotted(yes)
+    }
+
     fn key_decor_mut(&mut self, key: &str) -> Option<&mut Decor> {
         self.key_decor_mut(key)
     }

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -763,7 +763,7 @@ fn test_insert_dotted_into_std_table() {
 
             root["nixpkgs"]["src"] = table();
             root["nixpkgs"]["src"]
-                .as_table_mut()
+                .as_table_like_mut()
                 .unwrap()
                 .set_dotted(true);
             root["nixpkgs"]["src"]["git"] = value("https://github.com/nixos/nixpkgs");
@@ -784,7 +784,7 @@ fn test_insert_dotted_into_implicit_table() {
 
             root["nixpkgs"]["src"]["git"] = value("https://github.com/nixos/nixpkgs");
             root["nixpkgs"]["src"]
-                .as_inline_table_mut()
+                .as_table_like_mut()
                 .unwrap()
                 .set_dotted(true);
         })


### PR DESCRIPTION
Makes it so people can set dotting without worrying about what kind of table it is.