### PR TITLE
fix(toml_edit): Fuzz build error

### DIFF
--- a/crates/toml_edit/fuzz/Cargo.toml
+++ b/crates/toml_edit/fuzz/Cargo.toml
@@ -13,3 +13,5 @@ toml_edit = { path = ".." }
 [[bin]]
 name = "parse_document"
 path = "parse_document.rs"
+
+[workspace]


### PR DESCRIPTION
This fixes `crates/toml_edit/fuzz` not included in workspace error.