### PR TITLE
docs: Update fuzz readme

### DIFF
--- a/crates/toml_edit_fuzz/README.md
+++ b/crates/toml_edit_fuzz/README.md
@@ -4,5 +4,5 @@
 $ # install cargo fuzz (if you don't have it)
 $ cargo install cargo-fuzz
 $ # run fuzzer
-$ cargo +nightly fuzz run parse_document
+$ cargo +nightly fuzz run parse_document --fuzz-dir=.
 ```


### PR DESCRIPTION
Hi, Running `cargo +nightly fuzz run parse_document` will error out with:
```
Error: could not read the manifest file: toml/fuzz/Cargo.toml

Caused by:
    No such file or directory (os error 2)
```

As a solution, Running `cargo +nightly fuzz run parse_document --fuzz-dir=.` will point it to toml_edit_fuzz manifest file.