### PR TITLE
Fix typo in docs

### DIFF
--- a/crates/toml_edit/src/lib.rs
+++ b/crates/toml_edit/src/lib.rs
@@ -5,7 +5,7 @@
 //! # `toml_edit`
 //!
 //! This crate allows you to parse and modify toml
-//! documents, while preserving comments, spaces* and
+//! documents, while preserving comments, spaces *and
 //! relative order* or items.
 //!
 //! It is primarily tailored to the needs of [cargo-edit](https://github.com/killercup/cargo-edit/).


### PR DESCRIPTION
The space following the first asterisk meant that it was rendered as a literal asterisk instead of opening an emphasis region.

I also wonder about another typo in that sentence: was it intended to read "of items" instead of "or items"?  I wasn't sure about that one, so I left it unchanged for now.