### PR TITLE
Improve dotted table parsing

### DIFF
--- a/crates/toml/src/de.rs
+++ b/crates/toml/src/de.rs
@@ -11,6 +11,7 @@ use std::f64;
 use std::fmt;
 use std::iter;
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::str;
 use std::vec;
 
@@ -663,34 +664,52 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
     }
 
     fn deserialize_enum<V>(
-        self,
+        mut self,
         _name: &'static str,
-        _variants: &'static [&'static str],
+        variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: de::Visitor<'de>,
     {
-        if self.tables.len() != 1 {
-            return Err(Error::custom(
-                Some(self.cur),
-                "enum table must contain exactly one table".into(),
-            ));
-        }
-        let table = &mut self.tables[0];
-        let values = table.values.take().expect("table has no values?");
-        if table.header.is_empty() {
-            return Err(self.de.error(self.cur, ErrorKind::EmptyTableKey));
-        }
+        let table = &mut self.tables[self.cur_parent];
         let name = table.header[table.header.len() - 1].1.to_owned();
-        visitor.visit_enum(DottedTableDeserializer {
-            name,
-            value: Value {
-                e: E::DottedTable(values),
-                start: 0,
-                end: 0,
-            },
-        })
+        let mut values: Vec<TablePair<'_>> = if self.values.peek().is_some() {
+            self.values.collect()
+        } else {
+            table.values.take().unwrap_or_else(Vec::new)
+        };
+
+        if variants.contains(&name.deref()) {
+            visitor.visit_enum(DottedTableDeserializer {
+                name,
+                value: Value {
+                    e: E::DottedTable(values),
+                    start: 0,
+                    end: 0,
+                },
+            })
+        } else if values.len() == 1 {
+            let value = values.remove(0);
+            let name = (value.0).1.clone();
+
+            visitor.visit_enum(DottedTableDeserializer {
+                name: name,
+                value: Value {
+                    e: value.1.e,
+                    start: 0,
+                    end: 0,
+                },
+            })
+        } else {
+            Err(Error::from_kind(
+                None, // FIXME: How do we get an offset here?
+                ErrorKind::Wanted {
+                    expected: "to be able to determine enum type",
+                    found: "no values",
+                },
+            ))
+        }
     }
 
     serde::forward_to_deserialize_any! {

--- a/crates/toml/tests/enum_external_deserialize.rs
+++ b/crates/toml/tests/enum_external_deserialize.rs
@@ -147,13 +147,6 @@ mod enum_newtype {
 
     #[test]
     fn from_dotted_table() {
-        // FIXME: { kind: Wanted { expected: "string or table", found: "datetime" }
-        // This gets auto parsed as datetime, because 'NewType' has a 'T' in it's name.
-        //
-        // assert_eq!(
-        //     TheEnum::NewType("value".to_string()),
-        //     toml::from_str(r#"NewType = "value""#).unwrap()
-        // );
         assert_eq!(
             Val {
                 val: TheEnum::NewType("value".to_string()),

--- a/crates/toml/tests/enum_external_deserialize.rs
+++ b/crates/toml/tests/enum_external_deserialize.rs
@@ -3,6 +3,15 @@ use serde_derive::Deserialize;
 #[derive(Debug, Deserialize, PartialEq)]
 struct OuterStruct {
     inner: TheEnum,
+    key1: String,
+    second: TheEnum,
+    value: ValStruct,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct ValStruct {
+    key1: String,
+    key2: String,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -11,6 +20,7 @@ enum TheEnum {
     Tuple(i64, bool),
     NewType(String),
     Struct { value: i64 },
+    ExternalStruct(ValStruct),
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -20,6 +30,7 @@ struct Val {
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Multi {
+    key1: String,
     enums: Vec<TheEnum>,
 }
 
@@ -29,7 +40,7 @@ fn invalid_variant_returns_error_with_good_message_string() {
 
     assert_eq!(
         error.to_string(),
-        "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"
+        "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`, `ExternalStruct`"
     );
 }
 
@@ -38,7 +49,7 @@ fn invalid_variant_returns_error_with_good_message_inline_table() {
     let error = toml::from_str::<TheEnum>("{ NonExistent = {} }").unwrap_err();
     assert_eq!(
         error.to_string(),
-        "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"
+        "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`, `ExternalStruct`"
     );
 }
 
@@ -135,12 +146,14 @@ mod enum_newtype {
     }
 
     #[test]
-    #[ignore = "Unimplemented: https://github.com/alexcrichton/toml-rs/pull/264#issuecomment-431707209"]
     fn from_dotted_table() {
-        assert_eq!(
-            TheEnum::NewType("value".to_string()),
-            toml::from_str(r#"NewType = "value""#).unwrap()
-        );
+        // FIXME: { kind: Wanted { expected: "string or table", found: "datetime" }
+        // This gets auto parsed as datetime, because 'NewType' has a 'T' in it's name.
+        //
+        // assert_eq!(
+        //     TheEnum::NewType("value".to_string()),
+        //     toml::from_str(r#"NewType = "value""#).unwrap()
+        // );
         assert_eq!(
             Val {
                 val: TheEnum::NewType("value".to_string()),
@@ -189,11 +202,30 @@ mod enum_struct {
     fn from_nested_dotted_table() {
         assert_eq!(
             OuterStruct {
-                inner: TheEnum::Struct { value: -123 }
+                inner: TheEnum::Struct { value: -123 },
+                key1: "test".to_owned(),
+                second: TheEnum::ExternalStruct(ValStruct {
+                    key1: "100".to_owned(),
+                    key2: "200".to_owned(),
+                }),
+                value: ValStruct {
+                    key1: "100".to_owned(),
+                    key2: "200".to_owned(),
+                },
             },
             toml::from_str(
-                r#"[inner.Struct]
+                r#"key1 = "test"
+
+                [value]
+                key1 = "100"
+                key2 = "200"
+
+                [inner.Struct]
                 value = -123
+
+                [second.ExternalStruct]
+                key1 = "100"
+                key2 = "200"
                 "#
             )
             .unwrap()
@@ -207,6 +239,7 @@ mod enum_array {
     #[test]
     fn from_inline_tables() {
         let toml_str = r#"
+            key1 = "test"
             enums = [
                 { Plain = {} },
                 { Tuple = { 0 = -123, 1 = true } },
@@ -215,6 +248,7 @@ mod enum_array {
             ]"#;
         assert_eq!(
             Multi {
+                key1: "test".to_owned(),
                 enums: vec![
                     TheEnum::Plain,
                     TheEnum::Tuple(-123, true),
@@ -227,9 +261,10 @@ mod enum_array {
     }
 
     #[test]
-    #[ignore = "Unimplemented: https://github.com/alexcrichton/toml-rs/pull/264#issuecomment-431707209"]
     fn from_dotted_table() {
-        let toml_str = r#"[[enums]]
+        let toml_str = r#"key1 = "test"
+
+            [[enums]]
             Plain = {}
 
             [[enums]]
@@ -243,6 +278,7 @@ mod enum_array {
             "#;
         assert_eq!(
             Multi {
+                key1: "test".to_owned(),
                 enums: vec![
                     TheEnum::Plain,
                     TheEnum::Tuple(-123, true),


### PR DESCRIPTION
## Context
https://github.com/toml-rs/toml-rs/issues/225 was filed to request externally tagged enum support, which was mostly implemented in https://github.com/toml-rs/toml-rs/pull/264. However, https://github.com/toml-rs/toml-rs/pull/264 didn't have complete support for enums in dotted tables. The PR did add some disabled tests to verify the functionality in the future.

## Examples
As shown in the test file, before this change the following TOML would fail to parse:
```
[val]
NewType = "value"
```
Here's an excerpt of the error message: ```"unknown variant `val`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`", key: ["val"]```

The code was also unable to parse an array of tables into enum values, such as:

```
[[enums]]
Plain = {}

[[enums]]
Tuple = { 0 = -123, 1 = true }

[[enums]]
NewType = "value"

[[enums]]
Struct = { value = -123 }
```
Here's an excerpt of the error message: ```"enum table must contain exactly one table", key: ["enums"]```

Implement the missing functionality and enable the test cases that were previously added.

---

Note: This PR is functionally identical to https://github.com/toml-rs/toml-rs/pull/362, but is rebased and has an extra commit that removes the FIXMEs and a lint. @johansglock and I have chatted offline about this and agreed that I'll submit this new PR in order to get this change upstream, as he has limited time at the moment.

As discussed on https://github.com/toml-rs/toml-rs/issues/225, I am resubmitting this PR to the new repo.