### PR TITLE
fix(edit): Avoid leading newline on first nested table

### DIFF
--- a/crates/toml_edit/src/ser/mod.rs
+++ b/crates/toml_edit/src/ser/mod.rs
@@ -150,7 +150,8 @@ where
     T: serde::ser::Serialize,
 {
     let mut document = to_document(value)?;
-    pretty::Pretty.visit_document_mut(&mut document);
+    pretty::MakeItem.visit_document_mut(&mut document);
+    pretty::Pretty::new().visit_document_mut(&mut document);
     Ok(document.to_string())
 }
 

--- a/crates/toml_edit/src/ser/mod.rs
+++ b/crates/toml_edit/src/ser/mod.rs
@@ -150,8 +150,7 @@ where
     T: serde::ser::Serialize,
 {
     let mut document = to_document(value)?;
-    pretty::MakeItem.visit_document_mut(&mut document);
-    pretty::Pretty::new().visit_document_mut(&mut document);
+    pretty::Pretty.visit_document_mut(&mut document);
     Ok(document.to_string())
 }
 

--- a/crates/toml_edit/src/ser/pretty.rs
+++ b/crates/toml_edit/src/ser/pretty.rs
@@ -1,44 +1,21 @@
-pub(crate) struct Pretty {
-    depth: usize,
-    strip_prefix: bool,
-}
-
-impl Pretty {
-    pub(crate) fn new() -> Self {
-        Self {
-            depth: 0,
-            strip_prefix: true,
-        }
-    }
-}
+pub(crate) struct Pretty;
 
 impl crate::visit_mut::VisitMut for Pretty {
     fn visit_document_mut(&mut self, node: &mut crate::Document) {
-        match node.iter().next() {
-            Some((_, crate::Item::None)) | Some((_, crate::Item::Value(_))) | None => {
-                self.strip_prefix = false;
-            }
-            Some((_, crate::Item::Table(_))) | Some((_, crate::Item::ArrayOfTables(_))) => {}
-        }
         crate::visit_mut::visit_document_mut(self, node);
     }
 
-    fn visit_table_mut(&mut self, node: &mut crate::Table) {
-        self.depth += 1;
-        let implicit = !node.is_empty();
-        if 1 < self.depth {
-            node.decor_mut().clear();
+    fn visit_item_mut(&mut self, node: &mut crate::Item) {
+        node.make_item();
 
-            let children = node.get_values();
-            let is_visible_std_table = !(implicit && children.is_empty());
-            if is_visible_std_table && self.strip_prefix {
-                node.decor_mut().set_prefix("");
-                self.strip_prefix = false;
-            }
-        }
+        crate::visit_mut::visit_item_mut(self, node);
+    }
+
+    fn visit_table_mut(&mut self, node: &mut crate::Table) {
+        node.decor_mut().clear();
 
         // Empty tables could be semantically meaningful, so make sure they are not implicit
-        if implicit {
+        if !node.is_empty() {
             node.set_implicit(true);
         }
 
@@ -64,15 +41,5 @@ impl crate::visit_mut::VisitMut for Pretty {
             node.set_trailing("\n");
             node.set_trailing_comma(true);
         }
-    }
-}
-
-pub(crate) struct MakeItem;
-
-impl crate::visit_mut::VisitMut for MakeItem {
-    fn visit_item_mut(&mut self, node: &mut crate::Item) {
-        node.make_item();
-
-        crate::visit_mut::visit_item_mut(self, node);
     }
 }

--- a/crates/toml_edit/tests/convert.rs
+++ b/crates/toml_edit/tests/convert.rs
@@ -39,8 +39,7 @@ fn inline_table_to_table() {
     doc.insert("table", Item::Table(t));
 
     let actual = doc.to_string();
-    let expected = r#"
-[table]
+    let expected = r#"[table]
 string = "value"
 array = [1, 2, 3]
 inline = { "1" = 1, "2" = 2 }

--- a/crates/toml_edit/tests/serde.rs
+++ b/crates/toml_edit/tests/serde.rs
@@ -1,8 +1,9 @@
 #![cfg(feature = "easy")]
 
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+use serde::{Deserialize, Serialize};
+use snapbox::assert_eq;
 use toml_edit::easy::map::Map;
 use toml_edit::easy::Value;
 use toml_edit::easy::Value::{Array, Float, Integer, Table};
@@ -555,5 +556,152 @@ dev = { debug = 'a' }
     assert_eq!(
         err.to_string(),
         "expected a boolean or an integer for key `profile.dev.debug`"
+    );
+}
+
+#[test]
+fn newline_key_value() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Package {
+        name: String,
+    }
+
+    let package = Package {
+        name: "foo".to_owned(),
+    };
+    let raw = toml_edit::ser::to_string_pretty(&package).unwrap();
+    assert_eq(
+        r#"name = "foo"
+"#,
+        raw,
+    );
+}
+
+#[test]
+fn newline_table() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Manifest {
+        package: Package,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Package {
+        name: String,
+    }
+
+    let package = Manifest {
+        package: Package {
+            name: "foo".to_owned(),
+        },
+    };
+    let raw = toml_edit::ser::to_string_pretty(&package).unwrap();
+    assert_eq(
+        r#"[package]
+name = "foo"
+"#,
+        raw,
+    );
+}
+
+#[test]
+fn newline_dotted_table() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Manifest {
+        profile: Profile,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Profile {
+        dev: Dev,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Dev {
+        debug: U32OrBool,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+    #[serde(untagged, expecting = "expected a boolean or an integer")]
+    pub enum U32OrBool {
+        U32(u32),
+        Bool(bool),
+    }
+
+    let package = Manifest {
+        profile: Profile {
+            dev: Dev {
+                debug: U32OrBool::Bool(true),
+            },
+        },
+    };
+    let raw = toml_edit::ser::to_string_pretty(&package).unwrap();
+    assert_eq(
+        r#"
+[profile.dev]
+debug = true
+"#,
+        raw,
+    );
+}
+
+#[test]
+fn newline_mixed_tables() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Manifest {
+        cargo_features: Vec<String>,
+        package: Package,
+        profile: Profile,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Package {
+        name: String,
+        version: String,
+        authors: Vec<String>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Profile {
+        dev: Dev,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Dev {
+        debug: U32OrBool,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+    #[serde(untagged, expecting = "expected a boolean or an integer")]
+    pub enum U32OrBool {
+        U32(u32),
+        Bool(bool),
+    }
+
+    let package = Manifest {
+        cargo_features: vec![],
+        package: Package {
+            name: "foo".to_owned(),
+            version: "1.0.0".to_owned(),
+            authors: vec![],
+        },
+        profile: Profile {
+            dev: Dev {
+                debug: U32OrBool::Bool(true),
+            },
+        },
+    };
+    let raw = toml_edit::ser::to_string_pretty(&package).unwrap();
+    assert_eq(
+        r#"cargo_features = []
+
+[package]
+name = "foo"
+version = "1.0.0"
+authors = []
+
+[profile.dev]
+debug = true
+"#,
+        raw,
     );
 }

--- a/crates/toml_edit/tests/serde.rs
+++ b/crates/toml_edit/tests/serde.rs
@@ -636,8 +636,7 @@ fn newline_dotted_table() {
     };
     let raw = toml_edit::ser::to_string_pretty(&package).unwrap();
     assert_eq(
-        r#"
-[profile.dev]
+        r#"[profile.dev]
 debug = true
 "#,
         raw,

--- a/crates/toml_edit/tests/test_edit.rs
+++ b/crates/toml_edit/tests/test_edit.rs
@@ -54,6 +54,7 @@ impl Test {
         self
     }
 
+    #[track_caller]
     fn produces_display(&self, expected: &str) -> &Self {
         assert_eq(expected, self.doc.to_string());
         self
@@ -65,8 +66,7 @@ impl Test {
 #[test]
 fn test_insert_leaf_table() {
     given(
-        r#"
-        [servers]
+        r#"[servers]
 
         [servers.alpha]
         ip = "10.0.0.1"
@@ -80,8 +80,7 @@ fn test_insert_leaf_table() {
         root["servers"]["beta"]["dc"] = value("eqdc10");
     })
     .produces_display(
-        r#"
-        [servers]
+        r#"[servers]
 
         [servers.alpha]
         ip = "10.0.0.1"
@@ -199,8 +198,7 @@ fn test_insert_values() {
         root["tbl"]["key3"] = value(8.1415926);
     })
     .produces_display(
-        r#"
-[tbl]
+        r#"[tbl]
 key1 = "value1"
 key2 = 42
 key3 = 8.1415926
@@ -831,8 +829,7 @@ fn test_insert_dotted_into_std_table() {
             root["nixpkgs"]["src"]["git"] = value("https://github.com/nixos/nixpkgs");
         })
         .produces_display(
-            r#"
-[nixpkgs]
+            r#"[nixpkgs]
 src.git = "https://github.com/nixos/nixpkgs"
 "#,
         );
@@ -851,8 +848,7 @@ fn test_insert_dotted_into_implicit_table() {
                 .set_dotted(true);
         })
         .produces_display(
-            r#"
-[nixpkgs]
+            r#"[nixpkgs]
 src.git = "https://github.com/nixos/nixpkgs"
 "#,
         );


### PR DESCRIPTION
`to_string_pretty` tries to have newlines between tables but not extra leading/trailing newlines.  The leading newline logic was only working if the first table was visible.  If it was not visible, we put a newline before the first dotted table.

Now we avoid the newline before the first table, of any kind, and do this more generally with default decor and not just hard coded in `to_string_pretty`.

See also rust-lang/cargo#11271