### PR TITLE
fix(toml): Deprecate compat hacks

### DIFF
--- a/crates/toml/CHANGELOG.md
+++ b/crates/toml/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog].
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Compatibility
+
+- Deprecated  `Deserializer::set_require_newline_after_table`
+- Deprecated  `Deserializer::set_allow_duplicate_after_longer_table`
+
 ## [0.5.10] - 2022-12-14
 
 ## [0.5.9]

--- a/crates/toml/src/de.rs
+++ b/crates/toml/src/de.rs
@@ -1279,22 +1279,14 @@ impl<'a> Deserializer<'a> {
         Ok(())
     }
 
-    /// Historical versions of toml-rs accidentally allowed a newline after a
-    /// table definition, but the TOML spec requires a newline after a table
-    /// definition header.
-    ///
-    /// This option can be set to `false` (the default is `true`) to emulate
-    /// this behavior for backwards compatibility with older toml-rs versions.
+    #[doc(hidden)]
+    #[deprecated(since = "0.5.10")]
     pub fn set_require_newline_after_table(&mut self, require: bool) {
         self.require_newline_after_table = require;
     }
 
-    /// Historical versions of toml-rs accidentally allowed a duplicate table
-    /// header after a longer table header was previously defined. This is
-    /// invalid according to the TOML spec, however.
-    ///
-    /// This option can be set to `true` (the default is `false`) to emulate
-    /// this behavior for backwards compatibility with older toml-rs versions.
+    #[doc(hidden)]
+    #[deprecated(since = "0.5.10")]
     pub fn set_allow_duplicate_after_longer_table(&mut self, allow: bool) {
         self.allow_duplciate_after_longer_table = allow;
     }


### PR DESCRIPTION
`toml_edit` won't be able to support these.  For example, cargo moved away from these in https://github.com/rust-lang/cargo/pull/9932 to prepare for https://github.com/rust-lang/cargo/pull/10086

This is prep for #340