### PR TITLE
allows for empty `toml::toml!` invocations

### DIFF
--- a/crates/toml/src/macros.rs
+++ b/crates/toml/src/macros.rs
@@ -28,10 +28,13 @@ use crate::value::{Array, Table, Value};
 /// ```
 #[macro_export]
 macro_rules! toml {
-    ($($toml:tt)+) => {{
+    ($($toml:tt)*) => {{
         let table = $crate::value::Table::new();
+
+        #[allow(unused_mut)]
         let mut root = $crate::Value::Table(table);
-        $crate::toml_internal!(@toplevel root [] $($toml)+);
+
+        $crate::toml_internal!(@toplevel root [] $($toml)*);
         root
     }};
 }


### PR DESCRIPTION
I don't know too much about macros, so perhaps this is too noisy a change, but this simply allows calling `toml::toml!{}` without anything inside it, creating a blank `toml::Value::Table`. 

In unit tests, it can read more clearly for an empty toml document when other tests nearby are constructing real data, and it has a very small footprint, so it doesn't seem like an issue in general.