### PR TITLE
perf: Speed up compile times with nom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
-name = "bytes"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,16 +159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
 ]
 
 [[package]]
@@ -530,6 +514,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom8"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75d908f0297c3526d34e478d438b07eefe3d7b0416494d7ffccb17f1c7f7262c"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -924,11 +924,11 @@ dependencies = [
 name = "toml_edit"
 version = "0.15.0"
 dependencies = [
- "combine",
  "criterion",
  "indexmap",
  "itertools",
  "kstring",
+ "nom8",
  "serde",
  "serde_json",
  "snapbox",

--- a/crates/toml_edit/Cargo.toml
+++ b/crates/toml_edit/Cargo.toml
@@ -42,7 +42,7 @@ serde = ["dep:serde", "toml_datetime/serde"]
 
 [dependencies]
 indexmap = "1.9.1"
-combine = "4.6.6"
+nom8 = "0.1.0"
 itertools = "0.10.5"
 serde = { version = "1.0.145", features = ["derive"], optional = true }
 kstring = { version = "2.0.0", features = ["max_inline"], optional = true }

--- a/crates/toml_edit/src/document.rs
+++ b/crates/toml_edit/src/document.rs
@@ -70,7 +70,13 @@ impl FromStr for Document {
 
     /// Parses a document from a &str
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parser::document(s.as_bytes())
+        use nom8::prelude::*;
+
+        let b = s.as_bytes();
+        parser::document::document
+            .parse(b)
+            .finish()
+            .map_err(|e| Self::Err::new(e, b))
     }
 }
 

--- a/crates/toml_edit/src/parser/datetime.rs
+++ b/crates/toml_edit/src/parser/datetime.rs
@@ -1,94 +1,82 @@
-use combine::parser::byte::byte;
-use combine::parser::range::{recognize, take_while1};
-use combine::stream::RangeStream;
-use combine::*;
-use toml_datetime::*;
+use std::ops::RangeInclusive;
 
 use crate::parser::errors::CustomError;
+use crate::parser::prelude::*;
 use crate::parser::trivia::from_utf8_unchecked;
+
+use nom8::branch::alt;
+use nom8::bytes::one_of;
+use nom8::bytes::take_while_m_n;
+use nom8::combinator::cut;
+use nom8::combinator::opt;
+use nom8::sequence::preceded;
+use toml_datetime::*;
 
 // ;; Date and Time (as defined in RFC 3339)
 
 // date-time = offset-date-time / local-date-time / local-date / local-time
-// offset-date-time = full-date "T" full-time
-// local-date-time = full-date "T" partial-time
+// offset-date-time = full-date time-delim full-time
+// local-date-time = full-date time-delim partial-time
 // local-date = full-date
 // local-time = partial-time
 // full-time = partial-time time-offset
-parse!(date_time() -> Datetime, {
-    choice!(
-        (
-            full_date(),
-            optional((
-                attempt((
-                    satisfy(is_time_delim),
-                    look_ahead(time_hour())
-                )),
-                partial_time(),
-                optional(time_offset()),
-            ))
-        )
+pub(crate) fn date_time(input: Input<'_>) -> IResult<Input<'_>, Datetime, ParserError<'_>> {
+    alt((
+        (full_date, opt((time_delim, partial_time, opt(time_offset))))
             .map(|(date, opt)| {
                 match opt {
                     // Offset Date-Time
-                    Some((_, time, offset)) => {
-                        Datetime { date: Some(date), time: Some(time), offset }
-                    }
+                    Some((_, time, offset)) => Datetime {
+                        date: Some(date),
+                        time: Some(time),
+                        offset,
+                    },
                     // Local Date
-                    None => {
-                        Datetime { date: Some(date), time: None, offset: None}
+                    None => Datetime {
+                        date: Some(date),
+                        time: None,
+                        offset: None,
                     },
                 }
-            }),
-        // Local Time
-        partial_time()
-            .message("While parsing a Time")
-            .map(|t| {
-                t.into()
             })
-    )
-        .message("While parsing a Date-Time")
-});
+            .context(Context::Expression("date-time")),
+        partial_time
+            .map(|t| t.into())
+            .context(Context::Expression("time")),
+    ))
+    .parse(input)
+}
 
 // full-date      = date-fullyear "-" date-month "-" date-mday
-parse!(full_date() -> Date, {
-    (
-        attempt((date_fullyear(), byte(b'-'))),
-        date_month(),
-        byte(b'-'),
-        date_mday(),
-    ).map(|((year, _), month, _, day)| {
-        Date { year, month, day }
-    })
-});
+pub(crate) fn full_date(input: Input<'_>) -> IResult<Input<'_>, Date, ParserError<'_>> {
+    (date_fullyear, b'-', cut((date_month, b'-', date_mday)))
+        .map(|(year, _, (month, _, day))| Date { year, month, day })
+        .parse(input)
+}
 
 // partial-time   = time-hour ":" time-minute ":" time-second [time-secfrac]
-parse!(partial_time() -> Time, {
+pub(crate) fn partial_time(input: Input<'_>) -> IResult<Input<'_>, Time, ParserError<'_>> {
     (
-        attempt((
-            time_hour(),
-            byte(b':'),
-        )),
-        time_minute(),
-        byte(b':'),
-        time_second(),
-        optional(attempt(time_secfrac())),
-    ).map(|((hour, _), minute, _, second, nanosecond)| {
-        Time { hour, minute, second, nanosecond: nanosecond.unwrap_or_default() }
-    })
-});
+        time_hour,
+        b':',
+        cut((time_minute, b':', time_second, opt(time_secfrac))),
+    )
+        .map(|(hour, _, (minute, _, second, nanosecond))| Time {
+            hour,
+            minute,
+            second,
+            nanosecond: nanosecond.unwrap_or_default(),
+        })
+        .parse(input)
+}
 
 // time-offset    = "Z" / time-numoffset
 // time-numoffset = ( "+" / "-" ) time-hour ":" time-minute
-parse!(time_offset() -> Offset, {
-    attempt(satisfy(|c| c == b'Z' || c == b'z')).map(|_| Offset::Z)
-        .or(
-            (
-                attempt(choice([byte(b'+'), byte(b'-')])),
-                time_hour(),
-                byte(b':'),
-                time_minute(),
-            ).map(|(sign, hours, _, minutes)| {
+pub(crate) fn time_offset(input: Input<'_>) -> IResult<Input<'_>, Offset, ParserError<'_>> {
+    alt((
+        one_of((b'Z', b'z')).value(Offset::Z),
+        (one_of((b'+', b'-')), cut((time_hour, b':', time_minute))).map(
+            |(sign, (hours, _, minutes))| {
                 let hours = hours as i8;
                 let hours = match sign {
                     b'+' => hours,
@@ -96,121 +84,148 @@ parse!(time_offset() -> Offset, {
                     _ => unreachable!("Parser prevents this"),
                 };
                 Offset::Custom { hours, minutes }
-            })
-        ).message("While parsing a Time Offset")
-});
-
-// date-fullyear  = 4DIGIT
-parse!(date_fullyear() -> u16, {
-    signed_digits(4).map(|d| d as u16)
-});
-
-// date-month     = 2DIGIT  ; 01-12
-parse!(date_month() -> u8, {
-    unsigned_digits(2).map(|d| d as u8).and_then(|v| {
-        if (1..=12).contains(&v) {
-            Ok(v)
-        } else {
-            Err(CustomError::OutOfRange)
-        }
-    })
-});
-
-// date-mday      = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on month/year
-parse!(date_mday() -> u8, {
-    unsigned_digits(2).map(|d| d as u8).and_then(|v| {
-        if (1..=31).contains(&v) {
-            Ok(v)
-        } else {
-            Err(CustomError::OutOfRange)
-        }
-    })
-});
-
-// time-delim     = "T" / %x20 ; T, t, or space
-fn is_time_delim(c: u8) -> bool {
-    matches!(c, b'T' | b't' | b' ')
+            },
+        ),
+    ))
+    .context(Context::Expression("time offset"))
+    .parse(input)
 }
 
+// date-fullyear  = 4DIGIT
+pub(crate) fn date_fullyear(input: Input<'_>) -> IResult<Input<'_>, u16, ParserError<'_>> {
+    unsigned_digits::<4, 4>
+        .map(|s: &str| s.parse::<u16>().expect("4DIGIT should match u8"))
+        .parse(input)
+}
+
+// date-month     = 2DIGIT  ; 01-12
+pub(crate) fn date_month(input: Input<'_>) -> IResult<Input<'_>, u8, ParserError<'_>> {
+    unsigned_digits::<2, 2>
+        .map_res(|s: &str| {
+            let d = s.parse::<u8>().expect("2DIGIT should match u8");
+            if (1..=12).contains(&d) {
+                Ok(d)
+            } else {
+                Err(CustomError::OutOfRange)
+            }
+        })
+        .parse(input)
+}
+
+// date-mday      = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on month/year
+pub(crate) fn date_mday(input: Input<'_>) -> IResult<Input<'_>, u8, ParserError<'_>> {
+    unsigned_digits::<2, 2>
+        .map_res(|s: &str| {
+            let d = s.parse::<u8>().expect("2DIGIT should match u8");
+            if (1..=31).contains(&d) {
+                Ok(d)
+            } else {
+                Err(CustomError::OutOfRange)
+            }
+        })
+        .parse(input)
+}
+
+// time-delim     = "T" / %x20 ; T, t, or space
+pub(crate) fn time_delim(input: Input<'_>) -> IResult<Input<'_>, u8, ParserError<'_>> {
+    one_of(TIME_DELIM).parse(input)
+}
+
+const TIME_DELIM: (u8, u8, u8) = (b'T', b't', b' ');
+
 // time-hour      = 2DIGIT  ; 00-23
-parse!(time_hour() -> u8, {
-    unsigned_digits(2).map(|d| d as u8).and_then(|v| {
-        if (0..=23).contains(&v) {
-            Ok(v)
-        } else {
-            Err(CustomError::OutOfRange)
-        }
-    })
-});
+pub(crate) fn time_hour(input: Input<'_>) -> IResult<Input<'_>, u8, ParserError<'_>> {
+    unsigned_digits::<2, 2>
+        .map_res(|s: &str| {
+            let d = s.parse::<u8>().expect("2DIGIT should match u8");
+            if (0..=23).contains(&d) {
+                Ok(d)
+            } else {
+                Err(CustomError::OutOfRange)
+            }
+        })
+        .parse(input)
+}
 
 // time-minute    = 2DIGIT  ; 00-59
-parse!(time_minute() -> u8, {
-    unsigned_digits(2).map(|d| d as u8).and_then(|v| {
-        if (0..=59).contains(&v) {
-            Ok(v)
-        } else {
-            Err(CustomError::OutOfRange)
-        }
-    })
-});
+pub(crate) fn time_minute(input: Input<'_>) -> IResult<Input<'_>, u8, ParserError<'_>> {
+    unsigned_digits::<2, 2>
+        .map_res(|s: &str| {
+            let d = s.parse::<u8>().expect("2DIGIT should match u8");
+            if (0..=59).contains(&d) {
+                Ok(d)
+            } else {
+                Err(CustomError::OutOfRange)
+            }
+        })
+        .parse(input)
+}
 
 // time-second    = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second rules
-parse!(time_second() -> u8, {
-    unsigned_digits(2).map(|d| d as u8).and_then(|v| {
-        if (0..=60).contains(&v) {
-            Ok(v)
-        } else {
-            Err(CustomError::OutOfRange)
-        }
-    })
-});
+pub(crate) fn time_second(input: Input<'_>) -> IResult<Input<'_>, u8, ParserError<'_>> {
+    unsigned_digits::<2, 2>
+        .map_res(|s: &str| {
+            let d = s.parse::<u8>().expect("2DIGIT should match u8");
+            if (0..=60).contains(&d) {
+                Ok(d)
+            } else {
+                Err(CustomError::OutOfRange)
+            }
+        })
+        .parse(input)
+}
 
 // time-secfrac   = "." 1*DIGIT
-parse!(time_secfrac() -> u32, {
-    static SCALE: [u32; 10] =
-        [0, 100_000_000, 10_000_000, 1_000_000, 100_000, 10_000, 1_000, 100, 10, 1];
-    byte(b'.').and(take_while1(|c: u8| c.is_ascii_digit())).and_then::<_, _, CustomError>(|(_, repr): (u8, &[u8])| {
-        let mut repr = unsafe { from_utf8_unchecked(repr, "`is_ascii_digit` filters out on-ASCII") };
-        let max_digits = SCALE.len() - 1;
-        if max_digits < repr.len() {
-            // Millisecond precision is required. Further precision of fractional seconds is
-            // implementation-specific. If the value contains greater precision than the
-            // implementation can support, the additional precision must be truncated, not rounded.
-            repr = &repr[0..max_digits];
-        }
+pub(crate) fn time_secfrac(input: Input<'_>) -> IResult<Input<'_>, u32, ParserError<'_>> {
+    static SCALE: [u32; 10] = [
+        0,
+        100_000_000,
+        10_000_000,
+        1_000_000,
+        100_000,
+        10_000,
+        1_000,
+        100,
+        10,
+        1,
+    ];
+    const INF: usize = usize::MAX;
+    preceded(b'.', unsigned_digits::<1, INF>)
+        .map_res(|mut repr: &str| -> Result<u32, CustomError> {
+            let max_digits = SCALE.len() - 1;
+            if max_digits < repr.len() {
+                // Millisecond precision is required. Further precision of fractional seconds is
+                // implementation-specific. If the value contains greater precision than the
+                // implementation can support, the additional precision must be truncated, not rounded.
+                repr = &repr[0..max_digits];
+            }
 
-        let v = repr.parse::<u32>().map_err(|_| CustomError::OutOfRange)?;
-        let num_digits = repr.len();
+            let v = repr.parse::<u32>().map_err(|_| CustomError::OutOfRange)?;
+            let num_digits = repr.len();
 
-        // scale the number accordingly.
-        let scale = SCALE.get(num_digits).ok_or(CustomError::OutOfRange)?;
-        let v = v.checked_mul(*scale).ok_or(CustomError::OutOfRange)?;
-        Ok(v)
-    })
-});
+            // scale the number accordingly.
+            let scale = SCALE.get(num_digits).ok_or(CustomError::OutOfRange)?;
+            let v = v.checked_mul(*scale).ok_or(CustomError::OutOfRange)?;
+            Ok(v)
+        })
+        .parse(input)
+}
 
-parse!(signed_digits(count: usize) -> i32, {
-    recognize(skip_count_min_max(
-        *count, *count,
-        satisfy(|c: u8| c.is_ascii_digit()),
-    )).and_then(|b: &[u8]| {
-        let s = unsafe { from_utf8_unchecked(b, "`is_ascii_digit` filters out on-ASCII") };
-        s.parse::<i32>()
-    })
-});
+pub(crate) fn unsigned_digits<const MIN: usize, const MAX: usize>(
+    input: Input<'_>,
+) -> IResult<Input<'_>, &str, ParserError<'_>> {
+    take_while_m_n(MIN, MAX, DIGIT)
+        .map(|b: &[u8]| unsafe { from_utf8_unchecked(b, "`is_ascii_digit` filters out on-ASCII") })
+        .parse(input)
+}
 
-parse!(unsigned_digits(count: usize) -> u32, {
-    recognize(skip_count_min_max(
-        *count, *count,
-        satisfy(|c: u8| c.is_ascii_digit()),
-    )).and_then(|b: &[u8]| {
-        let s = unsafe { from_utf8_unchecked(b, "`is_ascii_digit` filters out on-ASCII") };
-        s.parse::<u32>()
-    })
-});
+// DIGIT = %x30-39 ; 0-9
+const DIGIT: RangeInclusive<u8> = b'0'..=b'9';
 
 #[cfg(test)]
 mod test {
+    use super::*;
+
     #[test]
     fn offset_date_time() {
         let inputs = [
@@ -219,7 +234,7 @@ mod test {
             "1979-05-27T00:32:00.999999-07:00",
         ];
         for input in inputs {
-            parsed_date_time_eq!(input, is_datetime);
+            date_time.parse(input.as_bytes()).finish().unwrap();
         }
     }
 
@@ -227,7 +242,7 @@ mod test {
     fn local_date_time() {
         let inputs = ["1979-05-27T07:32:00", "1979-05-27T00:32:00.999999"];
         for input in inputs {
-            parsed_date_time_eq!(input, is_datetime);
+            date_time.parse(input.as_bytes()).finish().unwrap();
         }
     }
 
@@ -235,7 +250,7 @@ mod test {
     fn local_date() {
         let inputs = ["1979-05-27", "2017-07-20"];
         for input in inputs {
-            parsed_date_time_eq!(input, is_datetime);
+            date_time.parse(input.as_bytes()).finish().unwrap();
         }
     }
 
@@ -243,13 +258,13 @@ mod test {
     fn local_time() {
         let inputs = ["07:32:00", "00:32:00.999999"];
         for input in inputs {
-            parsed_date_time_eq!(input, is_datetime);
+            date_time.parse(input.as_bytes()).finish().unwrap();
         }
     }
 
     #[test]
     fn time_fraction_truncated() {
         let input = "1987-07-05T17:45:00.123456789012345Z";
-        parsed_date_time_eq!(input, is_datetime);
+        date_time.parse(input.as_bytes()).finish().unwrap();
     }
 }

--- a/crates/toml_edit/src/parser/key.rs
+++ b/crates/toml_edit/src/parser/key.rs
@@ -1,9 +1,12 @@
-use combine::parser::byte::byte;
-use combine::parser::range::{recognize_with_value, take_while1};
-use combine::stream::RangeStream;
-use combine::*;
+use std::ops::RangeInclusive;
+
+use nom8::bytes::any;
+use nom8::bytes::take_while1;
+use nom8::combinator::peek;
+use nom8::multi::separated_list1;
 
 use crate::key::Key;
+use crate::parser::prelude::*;
 use crate::parser::strings::{basic_string, literal_string};
 use crate::parser::trivia::{from_utf8_unchecked, ws};
 use crate::repr::{Decor, Repr};
@@ -11,47 +14,57 @@ use crate::InternalString;
 
 // key = simple-key / dotted-key
 // dotted-key = simple-key 1*( dot-sep simple-key )
-parse!(key() -> Vec<Key>, {
-    sep_by1(
-        attempt((
-            ws(),
-            simple_key(),
-            ws(),
-        )).map(|(pre, (raw, key), suffix)| {
-            Key::new(key).with_repr_unchecked(Repr::new_unchecked(raw)).with_decor(Decor::new(pre, suffix))
+pub(crate) fn key(input: Input<'_>) -> IResult<Input<'_>, Vec<Key>, ParserError<'_>> {
+    separated_list1(
+        DOT_SEP,
+        (ws, simple_key, ws).map(|(pre, (raw, key), suffix)| {
+            Key::new(key)
+                .with_repr_unchecked(Repr::new_unchecked(raw))
+                .with_decor(Decor::new(pre, suffix))
         }),
-        byte(DOT_SEP)
-    ).expected("key")
-});
+    )
+    .context(Context::Expression("key"))
+    .parse(input)
+}
 
 // simple-key = quoted-key / unquoted-key
 // quoted-key = basic-string / literal-string
-parse!(simple_key() -> (&'a str, InternalString), {
-    recognize_with_value(
-        look_ahead(any()).then(|e| {
-            dispatch!(e;
-                crate::parser::strings::QUOTATION_MARK => basic_string().map(|s: String| s.into()),
-                crate::parser::strings::APOSTROPHE => literal_string().map(|s: &'a str| s.into()),
-                _ => unquoted_key().map(|s: &'a str| s.into()),
-            )
+pub(crate) fn simple_key(
+    input: Input<'_>,
+) -> IResult<Input<'_>, (&str, InternalString), ParserError<'_>> {
+    dispatch! {peek(any);
+        crate::parser::strings::QUOTATION_MARK => basic_string
+            .map(|s: std::borrow::Cow<'_, str>| s.as_ref().into()),
+        crate::parser::strings::APOSTROPHE => literal_string.map(|s: &str| s.into()),
+        _ => unquoted_key.map(|s: &str| s.into()),
+    }
+        .with_recognized()
+        .map(|(k, b)| {
+            let s = unsafe { from_utf8_unchecked(b, "If `quoted_key` or `unquoted_key` are valid, then their `recognize`d value is valid") };
+            (s, k)
         })
-    ).map(|(b, k)| {
-        let s = unsafe { from_utf8_unchecked(b, "If `quoted_key` or `unquoted_key` are valid, then their `recognize`d value is valid") };
-        (s, k)
-    })
-});
+        .parse(input)
+}
 
 // unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
-parse!(unquoted_key() -> &'a str, {
-    take_while1(is_unquoted_char).map(|b| {
-        unsafe { from_utf8_unchecked(b, "`is_unquoted_char` filters out on-ASCII") }
-    })
-});
-
-#[inline]
-pub(crate) fn is_unquoted_char(c: u8) -> bool {
-    matches!(c, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_')
+fn unquoted_key(input: Input<'_>) -> IResult<Input<'_>, &str, ParserError<'_>> {
+    take_while1(UNQUOTED_CHAR)
+        .map(|b| unsafe { from_utf8_unchecked(b, "`is_unquoted_char` filters out on-ASCII") })
+        .parse(input)
 }
+
+pub(crate) fn is_unquoted_char(c: u8) -> bool {
+    use nom8::input::FindToken;
+    UNQUOTED_CHAR.find_token(c)
+}
+
+const UNQUOTED_CHAR: (
+    RangeInclusive<u8>,
+    RangeInclusive<u8>,
+    RangeInclusive<u8>,
+    u8,
+    u8,
+) = (b'A'..=b'Z', b'a'..=b'z', b'0'..=b'9', b'-', b'_');
 
 // dot-sep   = ws %x2E ws  ; . Period
 const DOT_SEP: u8 = b'.';
@@ -59,9 +72,6 @@ const DOT_SEP: u8 = b'.';
 #[cfg(test)]
 mod test {
     use super::*;
-
-    use combine::stream::position::Stream;
-    use snapbox::assert_eq;
 
     #[test]
     fn keys() {
@@ -72,11 +82,8 @@ mod test {
         ];
 
         for (input, expected) in cases {
-            let parsed = simple_key().easy_parse(Stream::new(input.as_bytes()));
-            assert!(parsed.is_ok());
-            let ((.., k), rest) = parsed.unwrap();
-            assert_eq(k.as_str(), expected);
-            assert_eq!(rest.input.len(), 0);
+            let parsed = simple_key.parse(input.as_bytes()).finish();
+            assert_eq!(parsed, Ok((input, expected.into())), "Parsing {input:?}");
         }
     }
 }

--- a/crates/toml_edit/src/parser/macros.rs
+++ b/crates/toml_edit/src/parser/macros.rs
@@ -1,112 +1,13 @@
-#[doc(hidden)]
-#[macro_export]
-macro_rules! parse (
-    ($name:ident( $($arg: ident :  $arg_type: ty),* ) -> $ret:ty, $code:expr) => (
-        parser!{
-            pub(crate) fn $name['a, I]($($arg : $arg_type),*)(I) -> $ret
-                where
-                [I: RangeStream<
-                 Range = &'a [u8],
-                 Token = u8>,
-                 I::Error: ParseError<u8, &'a [u8], <I as StreamOnce>::Position>,
-                 <I::Error as ParseError<u8, &'a [u8], <I as StreamOnce>::Position>>::StreamError:
-                 From<std::num::ParseIntError> +
-                 From<std::num::ParseFloatError> +
-                 From<std::str::Utf8Error> +
-                 From<$crate::parser::errors::CustomError>
-                ]
-            {
-                $code
+macro_rules! dispatch {
+    ($match_parser: expr; $( $pat:pat $(if $pred:expr)? => $expr: expr ),+ $(,)? ) => {
+        move |i|
+        {
+            let (i, initial) = $match_parser.parse(i)?;
+            match initial {
+                $(
+                    $pat $(if $pred)? => $expr.parse(i),
+                )*
             }
         }
-    );
-);
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! toml_parser (
-    ($name:ident, $argh:ident, $closure:expr) => (
-        parser!{
-            fn $name['a, 'b, I]($argh: &'b RefCell<ParseState>)(I) -> ()
-            where
-                [I: RangeStream<
-                 Range = &'a [u8],
-                 Token = u8>,
-                 I::Error: ParseError<u8, &'a [u8], <I as StreamOnce>::Position>,
-                 <I::Error as ParseError<u8, &'a [u8], <I as StreamOnce>::Position>>::StreamError:
-                 From<std::num::ParseIntError> +
-                 From<std::num::ParseFloatError> +
-                 From<std::str::Utf8Error> +
-                 From<$crate::parser::errors::CustomError>
-                ]
-            {
-                $closure
-            }
-        }
-    );
-);
-
-#[cfg(test)]
-macro_rules! parsed_eq {
-    ($parsed:ident, $expected:expr) => {{
-        assert!($parsed.is_ok(), "{:?}", $parsed.err().unwrap());
-        let (v, rest) = $parsed.unwrap();
-        assert_eq!(v, $expected);
-        assert!(rest.input.is_empty());
-    }};
-}
-
-#[cfg(test)]
-macro_rules! parsed_float_eq {
-    ($input:ident, $expected:expr) => {{
-        let parsed = crate::parser::numbers::float().easy_parse(Stream::new($input.as_bytes()));
-        let (v, rest) = match parsed {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                panic!("Unexpected error for {:?}: {:?}", $input, err);
-            }
-        };
-        if $expected.is_nan() {
-            assert!(v.is_nan());
-        } else if $expected.is_infinite() {
-            assert!(v.is_infinite());
-            assert_eq!($expected.is_sign_positive(), v.is_sign_positive());
-        } else {
-            dbg!($expected);
-            dbg!(v);
-            assert!(($expected - v).abs() < std::f64::EPSILON);
-        }
-        assert!(rest.input.is_empty());
-    }};
-}
-
-#[cfg(test)]
-macro_rules! parsed_value_eq {
-    ($input:expr) => {
-        use combine::EasyParser;
-        let parsed = crate::parser::value::value()
-            .easy_parse(combine::stream::position::Stream::new($input.as_bytes()));
-        let (v, rest) = match parsed {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                panic!("Unexpected error for {:?}: {:?}", $input, err);
-            }
-        };
-        snapbox::assert_eq(v.to_string(), $input);
-        assert!(rest.input.is_empty());
-    };
-}
-
-#[cfg(test)]
-macro_rules! parsed_date_time_eq {
-    ($input:expr, $is:ident) => {{
-        use combine::EasyParser;
-        let parsed = crate::parser::value::value()
-            .easy_parse(combine::stream::position::Stream::new($input.as_bytes()));
-        assert!(parsed.is_ok());
-        let (v, rest) = parsed.unwrap();
-        snapbox::assert_eq(v.to_string(), $input);
-        assert!(rest.input.is_empty());
-        assert!(v.$is());
-    }};
+    }
 }

--- a/crates/toml_edit/src/parser/mod.rs
+++ b/crates/toml_edit/src/parser/mod.rs
@@ -1,26 +1,64 @@
-#![allow(clippy::unneeded_field_pattern)]
-#![allow(clippy::toplevel_ref_arg)]
+#![allow(clippy::type_complexity)]
 
 #[macro_use]
-mod macros;
-mod array;
+pub(crate) mod macros;
+
+pub(crate) mod array;
 pub(crate) mod datetime;
-mod document;
-mod errors;
-mod inline_table;
-mod key;
+pub(crate) mod document;
+pub(crate) mod errors;
+pub(crate) mod inline_table;
+pub(crate) mod key;
 pub(crate) mod numbers;
-mod state;
+pub(crate) mod state;
 pub(crate) mod strings;
-mod table;
-mod trivia;
-mod value;
+pub(crate) mod table;
+pub(crate) mod trivia;
+pub(crate) mod value;
 
-pub(crate) use self::document::document;
-pub use self::errors::TomlError;
-pub(crate) use self::key::is_unquoted_char;
-pub(crate) use self::key::key as key_path;
-pub(crate) use self::key::simple_key;
-pub(crate) use self::value::value as value_parser;
+pub use errors::TomlError;
 
-use self::state::ParseState;
+mod prelude {
+    pub(crate) use super::errors::Context;
+    pub(crate) use super::errors::ParserError;
+    pub(crate) use super::errors::ParserValue;
+    pub(crate) use nom8::IResult;
+    pub(crate) use nom8::Parser as _;
+
+    #[cfg(test)]
+    pub(crate) use nom8::FinishIResult as _;
+
+    pub(crate) type Input<'b> = &'b [u8];
+
+    pub(crate) fn ok_error<I, O, E>(res: IResult<I, O, E>) -> Result<Option<(I, O)>, nom8::Err<E>> {
+        match res {
+            Ok(ok) => Ok(Some(ok)),
+            Err(nom8::Err::Error(_)) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn trace<I: std::fmt::Debug, O: std::fmt::Debug, E: std::fmt::Debug>(
+        context: impl std::fmt::Display,
+        mut parser: impl nom8::Parser<I, O, E>,
+    ) -> impl FnMut(I) -> IResult<I, O, E> {
+        static DEPTH: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        move |input: I| {
+            let depth = DEPTH.fetch_add(1, std::sync::atomic::Ordering::SeqCst) * 2;
+            eprintln!("{:depth$}--> {} {:?}", "", context, input);
+            match parser.parse(input) {
+                Ok((i, o)) => {
+                    DEPTH.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                    eprintln!("{:depth$}<-- {} {:?}", "", context, i);
+                    Ok((i, o))
+                }
+                Err(err) => {
+                    DEPTH.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                    eprintln!("{:depth$}<-- {} {:?}", "", context, err);
+                    Err(err)
+                }
+            }
+        }
+    }
+}

--- a/crates/toml_edit/tests/fixtures/invalid/datetime-malformed-no-leads.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/datetime-malformed-no-leads.stderr
@@ -1,6 +1,5 @@
-TOML parse error at line 1, column 18
+TOML parse error at line 1, column 17
   |
 1 | no-leads = 1987-7-05T17:45:00Z
-  |                  ^
-expected 1 more elements
-While parsing a Date-Time
+  |                 ^
+Invalid date-time

--- a/crates/toml_edit/tests/fixtures/invalid/datetime-malformed-no-secs.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/datetime-malformed-no-secs.stderr
@@ -2,6 +2,4 @@ TOML parse error at line 1, column 27
   |
 1 | no-secs = 1987-07-05T17:45Z
   |                           ^
-Unexpected `Z`
-Expected `:`
-While parsing a Date-Time
+Invalid date-time

--- a/crates/toml_edit/tests/fixtures/invalid/datetime-malformed-no-t.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/datetime-malformed-no-t.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 18
   |
 1 | no-t = 1987-07-0517:45:00Z
   |                  ^
-Unexpected `1`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/datetime-malformed-with-milli.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/datetime-malformed-with-milli.stderr
@@ -1,6 +1,5 @@
-TOML parse error at line 1, column 23
+TOML parse error at line 1, column 22
   |
 1 | with-milli = 1987-07-5T17:45:00.12Z
-  |                       ^
-expected 1 more elements
-While parsing a Date-Time
+  |                      ^
+Invalid date-time

--- a/crates/toml_edit/tests/fixtures/invalid/duplicate-key-dotted-into-std.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/duplicate-key-dotted-into-std.stderr
@@ -3,4 +3,3 @@ TOML parse error at line 5, column 1
 5 | apple.color = "red"
   | ^
 Duplicate key `color`
-

--- a/crates/toml_edit/tests/fixtures/invalid/duplicate-key-std-into-dotted.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/duplicate-key-std-into-dotted.stderr
@@ -3,4 +3,3 @@ TOML parse error at line 6, column 1
 6 | size = "small"
   | ^
 Duplicate key `size`
-

--- a/crates/toml_edit/tests/fixtures/invalid/duplicate-key-table.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/duplicate-key-table.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 4, column 1
   |
 4 | [fruit.type]
   | ^
+Invalid table header
 Duplicate key `type` in table `fruit`
-
-While parsing a Table Header

--- a/crates/toml_edit/tests/fixtures/invalid/duplicate-keys-cargo.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/duplicate-keys-cargo.stderr
@@ -3,4 +3,3 @@ TOML parse error at line 7, column 1
 7 | categories = ["algorithms"]
   | ^
 Duplicate key `categories` in table `project`
-

--- a/crates/toml_edit/tests/fixtures/invalid/duplicate-keys-dotted.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/duplicate-keys-dotted.stderr
@@ -3,4 +3,3 @@ TOML parse error at line 3, column 1
 3 | ssl-version.min = 'tlsv1.2'
   | ^
 Dotted key `ssl-version` attempted to extend non-table type (string)
-

--- a/crates/toml_edit/tests/fixtures/invalid/duplicate-keys.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/duplicate-keys.stderr
@@ -3,4 +3,3 @@ TOML parse error at line 2, column 1
 2 | dupe = true
   | ^
 Duplicate key `dupe` in document root
-

--- a/crates/toml_edit/tests/fixtures/invalid/duplicate-tables.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/duplicate-tables.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 2, column 1
   |
 2 | [a]
   | ^
+Invalid table header
 Duplicate key `a` in document root
-
-While parsing a Table Header

--- a/crates/toml_edit/tests/fixtures/invalid/empty-implicit-table.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/empty-implicit-table.stderr
@@ -1,6 +1,6 @@
-TOML parse error at line 1, column 10
+TOML parse error at line 1, column 9
   |
 1 | [naughty..naughty]
-  |          ^
-Unexpected `.`
-While parsing a Table Header
+  |         ^
+Invalid table header
+Expected `.`, `]`

--- a/crates/toml_edit/tests/fixtures/invalid/empty-table.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/empty-table.stderr
@@ -2,6 +2,4 @@ TOML parse error at line 1, column 2
   |
 1 | []
   |  ^
-Unexpected `]`
-Expected key
-While parsing a Table Header
+Invalid key

--- a/crates/toml_edit/tests/fixtures/invalid/float-leading-zero-neg.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-leading-zero-neg.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 18
   |
 1 | leading-zero = -03.14
   |                  ^
-Unexpected `3`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/float-leading-zero-pos.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-leading-zero-pos.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 18
   |
 1 | leading-zero = +03.14
   |                  ^
-Unexpected `3`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/float-leading-zero.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-leading-zero.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 17
   |
 1 | leading-zero = 03.14
   |                 ^
-Unexpected `3`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/float-no-leading-zero.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-no-leading-zero.stderr
@@ -2,14 +2,5 @@ TOML parse error at line 1, column 10
   |
 1 | answer = .12345
   |          ^
-Unexpected `.`
-Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
-expected 4 more elements
-expected 2 more elements
-While parsing a Time
-While parsing a hexadecimal Integer
-While parsing a octal Integer
-While parsing a binary Integer
-While parsing an Integer
-While parsing a Date-Time
-While parsing a Float
+Invalid floating-point number
+Expected leading digit

--- a/crates/toml_edit/tests/fixtures/invalid/float-no-trailing-digits.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-no-trailing-digits.stderr
@@ -2,7 +2,5 @@ TOML parse error at line 1, column 12
   |
 1 | answer = 1.
   |            ^
-Unexpected `
-`
+Invalid floating-point number
 Expected digit
-While parsing a Float

--- a/crates/toml_edit/tests/fixtures/invalid/float-underscore-after-point.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-underscore-after-point.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 9
   |
 1 | bad = 1._2
   |         ^
-Unexpected `_`
+Invalid floating-point number
 Expected digit
-While parsing a Float

--- a/crates/toml_edit/tests/fixtures/invalid/float-underscore-after.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-underscore-after.stderr
@@ -2,7 +2,5 @@ TOML parse error at line 1, column 11
   |
 1 | bad = 1.2_
   |           ^
-Unexpected `
-`
-Expected digit
-While parsing a Float
+Invalid floating-point number
+Expected digit, digit

--- a/crates/toml_edit/tests/fixtures/invalid/float-underscore-before-point.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-underscore-before-point.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 9
   |
 1 | bad = 1_.2
   |         ^
-Unexpected `.`
+Invalid integer
 Expected digit
-While parsing an Integer

--- a/crates/toml_edit/tests/fixtures/invalid/float-underscore-before.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/float-underscore-before.stderr
@@ -2,14 +2,5 @@ TOML parse error at line 1, column 7
   |
 1 | bad = _1.2
   |       ^
-Unexpected `_`
-Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
-expected 4 more elements
-expected 2 more elements
-While parsing a Time
-While parsing a hexadecimal Integer
-While parsing a octal Integer
-While parsing a binary Integer
-While parsing an Integer
-While parsing a Date-Time
-While parsing a Float
+Invalid integer
+Expected leading digit

--- a/crates/toml_edit/tests/fixtures/invalid/inline-table-newline.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/inline-table-newline.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 7, column 11
   |
 7 | native = {
   |           ^
-Unexpected `
-`
-Expected key
+Invalid inline table
+Expected `}`

--- a/crates/toml_edit/tests/fixtures/invalid/integer-invalid-binary-char.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-invalid-binary-char.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 11
   |
 1 | bad = 0b102
   |           ^
-Unexpected `2`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/integer-invalid-hex-char.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-invalid-hex-char.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 11
   |
 1 | bad = 0x12g
   |           ^
-Unexpected `g`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/integer-invalid-octal-char.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-invalid-octal-char.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 11
   |
 1 | bad = 0o758
   |           ^
-Unexpected `8`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/integer-leading-zero-neg.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-leading-zero-neg.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 18
   |
 1 | leading-zero = -012
   |                  ^
-Unexpected `1`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/integer-leading-zero-pos.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-leading-zero-pos.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 18
   |
 1 | leading-zero = +012
   |                  ^
-Unexpected `1`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/integer-leading-zero.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-leading-zero.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 17
   |
 1 | leading-zero = 012
   |                 ^
-Unexpected `1`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/integer-underscore-after.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-underscore-after.stderr
@@ -2,7 +2,5 @@ TOML parse error at line 1, column 11
   |
 1 | bad = 123_
   |           ^
-Unexpected `
-`
+Invalid integer
 Expected digit
-While parsing an Integer

--- a/crates/toml_edit/tests/fixtures/invalid/integer-underscore-before.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-underscore-before.stderr
@@ -2,14 +2,5 @@ TOML parse error at line 1, column 7
   |
 1 | bad = _123
   |       ^
-Unexpected `_`
-Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
-expected 4 more elements
-expected 2 more elements
-While parsing a Time
-While parsing a hexadecimal Integer
-While parsing a octal Integer
-While parsing a binary Integer
-While parsing an Integer
-While parsing a Date-Time
-While parsing a Float
+Invalid integer
+Expected leading digit

--- a/crates/toml_edit/tests/fixtures/invalid/integer-underscore-double.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/integer-underscore-double.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 9
   |
 1 | bad = 1__23
   |         ^
-Unexpected `_`
+Invalid integer
 Expected digit
-While parsing an Integer

--- a/crates/toml_edit/tests/fixtures/invalid/key-after-array.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-after-array.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 14
   |
 1 | [[agencies]] owner = "S Cjelli"
   |              ^
-Unexpected `o`
-Expected newline or end of input
-While parsing a Table Header
+Invalid table header
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/key-after-table.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-after-table.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 9
   |
 1 | [error] this = "should not be here"
   |         ^
-Unexpected `t`
-Expected newline or end of input
-While parsing a Table Header
+Invalid table header
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/key-empty.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-empty.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 2
   |
 1 |  = 1
   |  ^
-Unexpected `=`
-Expected key
+Invalid key

--- a/crates/toml_edit/tests/fixtures/invalid/key-hash.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-hash.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 2
   |
 1 | a# = 1
   |  ^
-Unexpected `#`
-Expected `.` or `=`
+Expected `.`, `=`

--- a/crates/toml_edit/tests/fixtures/invalid/key-newline.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-newline.stderr
@@ -2,6 +2,4 @@ TOML parse error at line 1, column 2
   |
 1 | a
   |  ^
-Unexpected `
-`
-Expected `.` or `=`
+Expected `.`, `=`

--- a/crates/toml_edit/tests/fixtures/invalid/key-no-eol.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-no-eol.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 7
   |
 1 | a = 1 b = 2
   |       ^
-Unexpected `b`
-Expected newline or end of input
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/key-open-bracket.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-open-bracket.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 6
   |
 1 | [abc = 1
   |      ^
-Unexpected `=`
-Expected `.` or `]`
-While parsing a Table Header
+Invalid table header
+Expected `.`, `]`

--- a/crates/toml_edit/tests/fixtures/invalid/key-single-open-bracket.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-single-open-bracket.stderr
@@ -1,7 +1,5 @@
-TOML parse error at line 1, column 2
+TOML parse error at line 1, column 1
   |
 1 | [
-  |  ^
-Unexpected end of input
-Expected key
-While parsing a Table Header
+  | ^
+Invalid table header

--- a/crates/toml_edit/tests/fixtures/invalid/key-space.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-space.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 3
   |
 1 | a b = 1
   |   ^
-Unexpected `b`
-Expected `.` or `=`
+Expected `.`, `=`

--- a/crates/toml_edit/tests/fixtures/invalid/key-start-bracket.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-start-bracket.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 2, column 6
   |
 2 | [xyz = 5
   |      ^
-Unexpected `=`
-Expected `.` or `]`
-While parsing a Table Header
+Invalid table header
+Expected `.`, `]`

--- a/crates/toml_edit/tests/fixtures/invalid/key-two-equals.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key-two-equals.stderr
@@ -2,5 +2,5 @@ TOML parse error at line 1, column 6
   |
 1 | key= = 1
   |      ^
-Unexpected `=`
-Expected quoted string
+Invalid string
+Expected `"`, `'`

--- a/crates/toml_edit/tests/fixtures/invalid/llbrace.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/llbrace.stderr
@@ -2,7 +2,4 @@ TOML parse error at line 1, column 3
   |
 1 | [ [table]]
   |   ^
-Unexpected `[`
-Unexpected ` `
-Expected key
-While parsing a Table Header
+Invalid key

--- a/crates/toml_edit/tests/fixtures/invalid/rrbrace.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/rrbrace.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 8
   |
 1 | [[table] ]
   |        ^
-Unexpected `]`
-Expected `.` or `]]`
-While parsing a Table Header
+Invalid table header
+Expected `.`, `]]`

--- a/crates/toml_edit/tests/fixtures/invalid/string-bad-byte-escape.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-bad-byte-escape.stderr
@@ -1,7 +1,6 @@
-TOML parse error at line 1, column 13
+TOML parse error at line 1, column 14
   |
 1 | naughty = "\xAg"
-  |             ^
-Unexpected `x`
-While parsing escape sequence
-While parsing a Basic String
+  |              ^
+Invalid escape sequence
+Expected `b`, `f`, `n`, `r`, `t`, `u`, `U`, `\`, `"`

--- a/crates/toml_edit/tests/fixtures/invalid/string-bad-escape.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-bad-escape.stderr
@@ -1,7 +1,6 @@
-TOML parse error at line 1, column 42
+TOML parse error at line 1, column 43
   |
 1 | invalid-escape = "This string has a bad \a escape character."
-  |                                          ^
-Unexpected `a`
-While parsing escape sequence
-While parsing a Basic String
+  |                                           ^
+Invalid escape sequence
+Expected `b`, `f`, `n`, `r`, `t`, `u`, `U`, `\`, `"`

--- a/crates/toml_edit/tests/fixtures/invalid/string-bad-surrogate.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-bad-surrogate.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 15
   |
 1 | notgood = "a\uDCFF"
   |               ^
-Invalid hex escape code: dcff 
-
-While parsing a Basic String
+Invalid unicode 4-digit hex code
+Value is out of range

--- a/crates/toml_edit/tests/fixtures/invalid/string-bad-uni-esc.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-bad-uni-esc.stderr
@@ -1,6 +1,5 @@
-TOML parse error at line 1, column 14
+TOML parse error at line 1, column 13
   |
 1 | str = "val\ue"
-  |              ^
-expected 3 more elements
-While parsing a Basic String
+  |             ^
+Invalid unicode 4-digit hex code

--- a/crates/toml_edit/tests/fixtures/invalid/string-byte-escapes.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-byte-escapes.stderr
@@ -1,7 +1,6 @@
-TOML parse error at line 1, column 12
+TOML parse error at line 1, column 13
   |
 1 | answer = "\x33"
-  |            ^
-Unexpected `x`
-While parsing escape sequence
-While parsing a Basic String
+  |             ^
+Invalid escape sequence
+Expected `b`, `f`, `n`, `r`, `t`, `u`, `U`, `\`, `"`

--- a/crates/toml_edit/tests/fixtures/invalid/string-no-close.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-no-close.stderr
@@ -2,7 +2,4 @@ TOML parse error at line 1, column 42
   |
 1 | no-ending-quote = "One time, at band camp
   |                                          ^
-Unexpected `
-`
-Expected `"`
-While parsing a Basic String
+Invalid basic string

--- a/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-constant-like.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-constant-like.stderr
@@ -2,5 +2,5 @@ TOML parse error at line 1, column 7
   |
 1 | value=trust
   |       ^
-Unexpected `t`
-Expected quoted string
+Invalid string
+Expected `"`, `'`

--- a/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-in-array.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-in-array.stderr
@@ -2,5 +2,5 @@ TOML parse error at line 1, column 10
   |
 1 | value = [ZZZ]
   |          ^
-Unexpected `Z`
-Expected newline or `#`
+Invalid array
+Expected `]`

--- a/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-in-inline-table.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-in-inline-table.stderr
@@ -2,5 +2,5 @@ TOML parse error at line 1, column 17
   |
 1 | value = { key = ZZZ }
   |                 ^
-Unexpected `Z`
-Expected quoted string
+Invalid string
+Expected `"`, `'`

--- a/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-in-table.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-in-table.stderr
@@ -2,5 +2,5 @@ TOML parse error at line 1, column 7
   |
 1 | value=ZZZ
   |       ^
-Unexpected `Z`
-Expected quoted string
+Invalid string
+Expected `"`, `'`

--- a/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-number-like.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string-no-quotes-number-like.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 10
   |
 1 | value=123hello
   |          ^
-Unexpected `h`
-Expected `#`
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/table-array-implicit.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table-array-implicit.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 13, column 1
    |
 13 | [[albums]]
    | ^
+Invalid table header
 Duplicate key `albums` in document root
-
-While parsing a Table Header

--- a/crates/toml_edit/tests/fixtures/invalid/table-array-malformed-bracket.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table-array-malformed-bracket.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 9
   |
 1 | [[albums]
   |         ^
-Unexpected `]`
-Expected `.` or `]]`
-While parsing a Table Header
+Invalid table header
+Expected `.`, `]]`

--- a/crates/toml_edit/tests/fixtures/invalid/table-array-malformed-empty.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table-array-malformed-empty.stderr
@@ -2,6 +2,4 @@ TOML parse error at line 1, column 3
   |
 1 | [[]]
   |   ^
-Unexpected `]`
-Expected key
-While parsing a Table Header
+Invalid key

--- a/crates/toml_edit/tests/fixtures/invalid/table-empty.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table-empty.stderr
@@ -2,6 +2,4 @@ TOML parse error at line 1, column 2
   |
 1 | []
   |  ^
-Unexpected `]`
-Expected key
-While parsing a Table Header
+Invalid key

--- a/crates/toml_edit/tests/fixtures/invalid/table-nested-brackets-close.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table-nested-brackets-close.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 4
   |
 1 | [a]b]
   |    ^
-Unexpected `b`
-Expected `#`
-While parsing a Table Header
+Invalid table header
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/table-nested-brackets-open.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table-nested-brackets-open.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 3
   |
 1 | [a[b]
   |   ^
-Unexpected `[`
-Expected `.` or `]`
-While parsing a Table Header
+Invalid table header
+Expected `.`, `]`

--- a/crates/toml_edit/tests/fixtures/invalid/table-whitespace.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table-whitespace.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 10
   |
 1 | [invalid key]
   |          ^
-Unexpected `k`
-Expected `.` or `]`
-While parsing a Table Header
+Invalid table header
+Expected `.`, `]`

--- a/crates/toml_edit/tests/fixtures/invalid/table-with-pound.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table-with-pound.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 5
   |
 1 | [key#group]
   |     ^
-Unexpected `#`
-Expected `.` or `]`
-While parsing a Table Header
+Invalid table header
+Expected `.`, `]`

--- a/crates/toml_edit/tests/fixtures/invalid/text-after-array-entries.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/text-after-array-entries.stderr
@@ -2,5 +2,5 @@ TOML parse error at line 2, column 46
   |
 2 |   "Is there life after an array separator?", No
   |                                              ^
-Unexpected `N`
+Invalid array
 Expected `]`

--- a/crates/toml_edit/tests/fixtures/invalid/text-after-integer.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/text-after-integer.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 13
   |
 1 | answer = 42 the ultimate answer?
   |             ^
-Unexpected `t`
-Expected newline or end of input
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/text-after-string.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/text-after-string.stderr
@@ -2,5 +2,4 @@ TOML parse error at line 1, column 41
   |
 1 | string = "Is there life after strings?" No.
   |                                         ^
-Unexpected `N`
-Expected newline or end of input
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/text-after-table.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/text-after-table.stderr
@@ -2,6 +2,5 @@ TOML parse error at line 1, column 9
   |
 1 | [error] this shouldn't be here
   |         ^
-Unexpected `t`
-Expected newline or end of input
-While parsing a Table Header
+Invalid table header
+Expected newline, `#`

--- a/crates/toml_edit/tests/fixtures/invalid/text-before-array-separator.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/text-before-array-separator.stderr
@@ -2,5 +2,5 @@ TOML parse error at line 2, column 46
   |
 2 |   "Is there life before an array separator?" No,
   |                                              ^
-Unexpected `N`
+Invalid array
 Expected `]`

--- a/crates/toml_edit/tests/fixtures/invalid/text-in-array.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/text-in-array.stderr
@@ -2,5 +2,5 @@ TOML parse error at line 3, column 3
   |
 3 |   I don't belong,
   |   ^
-Unexpected `I`
+Invalid array
 Expected `]`

--- a/crates/toml_edit/tests/test_parse.rs
+++ b/crates/toml_edit/tests/test_parse.rs
@@ -21,27 +21,6 @@ macro_rules! test_key {
     }};
 }
 
-macro_rules! parse_error {
-    ($input:expr, $ty:ty, $err_msg:expr) => {{
-        let res = $input.parse::<$ty>();
-        assert!(res.is_err());
-        let err = res.unwrap_err();
-        assert!(
-            err.to_string().find($err_msg).is_some(),
-            "Error was: `{:?}`",
-            err.to_string()
-        );
-    }};
-}
-
-#[test]
-fn test_parse_error() {
-    parse_error!("'hello'bla", Value, "Could not parse the line");
-    parse_error!(r#"{a = 2"#, Value, "Expected `}`");
-
-    parse_error!("'\"", Key, "Expected `'`");
-}
-
 #[test]
 fn test_key_from_str() {
     test_key!("a", "a");


### PR DESCRIPTION
This is using a short-lived fork `nom` until we can get the changes upstreamed.  Note that `combine` requires using `attempt` to backtrack while `nom` backtracks by default and requires `cut` to not backtrack.

I find the straight functions much easier to understand what is happening and this allows us to intermix procedural with declarative logic (e.g. in string processing I skipped combinators to make it easier to not require an allocation).

Regarding that allocation, we still do it but this opens the door for us to use `InternalString` for user values which might give us more of a performance boost (previously, the forced allocation made it a moot point to measure it).

Running `cargo clean -p toml_edit && time cargo check`, I get 3s for building `toml_edit` with `combine` and 0.5s for `nom`.

For runtime performance
- Parsing `cargo init`s generated manifest took 4% less time
- Parsing `cargo`s manifest took 2% less time
- 10 tables took 37% less time
- 100 tables took 41% less time
- Array of 10 tables took 38% less time
- Array of 100 tables took 40% less time

(some of this might be because we use `dispatch` more than before and some because our error reporting is less allocation heavy)

This is with Rust 1.66 on a i9-12900H processor under WSL2

Fixes #327