### PR TITLE
fix(parser): Limit recursion to block stackoverflow

### DIFF
--- a/crates/toml_edit/Cargo.toml
+++ b/crates/toml_edit/Cargo.toml
@@ -39,6 +39,12 @@ default = []
 easy = ["serde"]
 perf = ["dep:kstring"]
 serde = ["dep:serde", "toml_datetime/serde"]
+# Provide a method disable_recursion_limit to parse arbitrarily deep structures
+# without any consideration for overflowing the stack. Additionally you will
+# need to be careful around other recursive operations on the parsed result
+# which may overflow the stack after deserialization has completed, including,
+# but not limited to, Display and Debug and Drop impls.
+unbounded = []
 
 [dependencies]
 indexmap = "1.9.1"

--- a/crates/toml_edit/src/parser/document.rs
+++ b/crates/toml_edit/src/parser/document.rs
@@ -111,7 +111,7 @@ pub(crate) fn parse_keyval(
                 .context(Context::Expected(ParserValue::CharLiteral('='))),
             (
                 ws,
-                value,
+                value(RecursionCheck::default()),
                 line_trailing
                     .context(Context::Expected(ParserValue::CharLiteral('\n')))
                     .context(Context::Expected(ParserValue::CharLiteral('#'))),

--- a/crates/toml_edit/src/parser/errors.rs
+++ b/crates/toml_edit/src/parser/errors.rs
@@ -344,6 +344,8 @@ pub(crate) enum CustomError {
         actual: &'static str,
     },
     OutOfRange,
+    #[cfg_attr(feature = "unbounded", allow(dead_code))]
+    RecursionLimitExceeded,
 }
 
 impl CustomError {
@@ -394,6 +396,7 @@ impl Display for CustomError {
                 )
             }
             CustomError::OutOfRange => writeln!(f, "Value is out of range"),
+            CustomError::RecursionLimitExceeded => writeln!(f, "Recursion limit exceded"),
         }
     }
 }

--- a/crates/toml_edit/src/value.rs
+++ b/crates/toml_edit/src/value.rs
@@ -211,10 +211,13 @@ impl FromStr for Value {
 
     /// Parses a value from a &str
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use nom8::prelude::*;
+        use crate::parser::prelude::*;
+        use nom8::FinishIResult;
 
         let b = s.as_bytes();
-        let parsed = parser::value::value.parse(b).finish();
+        let parsed = parser::value::value(RecursionCheck::default())
+            .parse(b)
+            .finish();
         match parsed {
             Ok(mut value) => {
                 // Only take the repr and not decor, as its probably not intended

--- a/crates/toml_edit/tests/stackoverflow.rs
+++ b/crates/toml_edit/tests/stackoverflow.rs
@@ -1,0 +1,21 @@
+#[test]
+#[cfg(not(feature = "unbounded"))]
+fn array_recursion_limit() {
+    let depths = [(1, true), (20, true), (300, false)];
+    for (depth, is_ok) in depths {
+        let input = format!("x={}{}", &"[".repeat(depth), &"]".repeat(depth));
+        let document = input.parse::<toml_edit::Document>();
+        assert_eq!(document.is_ok(), is_ok, "depth: {}", depth);
+    }
+}
+
+#[test]
+#[cfg(not(feature = "unbounded"))]
+fn inline_table_recursion_limit() {
+    let depths = [(1, true), (20, true), (300, false)];
+    for (depth, is_ok) in depths {
+        let input = format!("x={}true{}", &"{ x = ".repeat(depth), &"}".repeat(depth));
+        let document = input.parse::<toml_edit::Document>();
+        assert_eq!(document.is_ok(), is_ok, "depth: {}", depth);
+    }
+}


### PR DESCRIPTION
Without the macros of the old parser, it was much easier to add new state for this.  I chose the limit of 128 as that is what serde_json does.

I didn't both exposing more configuration for this than the `unbounded` feature.  We can add more later if needed but I doubt that. Technically, this may break someone but the likelihood is extremely low, especially with how toml isn't exactly designed for arbitrary depth and with how recently this release was out.

Fixes #206