### PR TITLE
Make `toml_datetime` and `toml_edit` license fields valid SPDX

### DIFF
--- a/crates/toml_datetime/Cargo.toml
+++ b/crates/toml_datetime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "toml_datetime"
 version = "0.5.0"
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["encoding", "toml"]
 categories = ["encoding", "parser-implementations", "parsing", "config"]
 description = "A TOML-compatible datetime type"

--- a/crates/toml_edit/Cargo.toml
+++ b/crates/toml_edit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "toml_edit"
 version = "0.17.1"
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["encoding", "toml"]
 categories = ["encoding", "parser-implementations", "parsing", "config"]
 description = "Yet another format-preserving TOML parser."


### PR DESCRIPTION
Fixes the license field in `toml_datetime` and `toml_edit` so that they contain valid SPDX identifiers.

We believe this is currently causing our dependency reviews to fail like:

<img width="968" alt="image" src="https://user-images.githubusercontent.com/13578537/210896713-a9e73d94-ea2a-464b-a4b6-3e11626c1612.png">
