### PR TITLE
feat(de): Track spans in errors

### DIFF
--- a/crates/toml_edit/src/array.rs
+++ b/crates/toml_edit/src/array.rs
@@ -87,6 +87,12 @@ impl Array {
         &self.decor
     }
 
+    /// Returns the location within the original document
+    #[cfg(feature = "serde")]
+    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+        self.span.clone()
+    }
+
     pub(crate) fn despan(&mut self, input: &str) {
         self.span = None;
         self.decor.despan(input);

--- a/crates/toml_edit/src/de/inline_table.rs
+++ b/crates/toml_edit/src/de/inline_table.rs
@@ -57,10 +57,12 @@ impl<'de> serde::Deserializer<'de> for crate::InlineTable {
         if self.is_empty() {
             Err(crate::de::Error::custom(
                 "wanted exactly 1 element, found 0 elements",
+                self.span(),
             ))
         } else if self.len() != 1 {
             Err(crate::de::Error::custom(
                 "wanted exactly 1 element, more than 1 element",
+                self.span(),
             ))
         } else {
             visitor.visit_enum(crate::de::InlineTableMapAccess::new(self))
@@ -84,13 +86,16 @@ impl<'de> serde::de::IntoDeserializer<'de, crate::de::Error> for crate::InlineTa
 
 pub(crate) struct InlineTableMapAccess {
     iter: indexmap::map::IntoIter<crate::InternalString, crate::table::TableKeyValue>,
+    span: Option<std::ops::Range<usize>>,
     value: Option<(crate::InternalString, crate::Item)>,
 }
 
 impl InlineTableMapAccess {
     pub(crate) fn new(input: crate::InlineTable) -> Self {
+        let span = input.span();
         Self {
             iter: input.items.into_iter(),
+            span,
             value: None,
         }
     }
@@ -144,6 +149,7 @@ impl<'de> serde::de::EnumAccess<'de> for InlineTableMapAccess {
             None => {
                 return Err(Error::custom(
                     "expected table with exactly 1 entry, found empty table",
+                    self.span,
                 ));
             }
         };

--- a/crates/toml_edit/src/de/inline_table.rs
+++ b/crates/toml_edit/src/de/inline_table.rs
@@ -130,14 +130,13 @@ impl<'de> serde::de::MapAccess<'de> for InlineTableMapAccess {
         V: serde::de::DeserializeSeed<'de>,
     {
         match self.value.take() {
-            Some((k, v)) => {
+            Some((_k, v)) => {
                 let span = v.span();
                 seed.deserialize(crate::de::ItemDeserializer::new(v))
                     .map_err(|mut err| {
                         if err.span().is_none() {
                             err.set_span(span);
                         }
-                        err.parent_key(k);
                         err
                     })
             }

--- a/crates/toml_edit/src/de/item.rs
+++ b/crates/toml_edit/src/de/item.rs
@@ -46,7 +46,15 @@ impl<'de> serde::Deserializer<'de> for ItemDeserializer {
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_newtype_struct(self)
+        let span = self.input.span();
+        visitor
+            .visit_newtype_struct(self)
+            .map_err(|mut e: Self::Error| {
+                if e.span().is_none() {
+                    e.set_span(span);
+                }
+                e
+            })
     }
 
     fn deserialize_struct<V>(
@@ -98,10 +106,28 @@ impl<'de> serde::Deserializer<'de> for crate::Item {
     where
         V: serde::de::Visitor<'de>,
     {
+        let span = self.span();
         match self {
-            crate::Item::None => visitor.visit_none(),
-            crate::Item::Value(v) => v.deserialize_any(visitor),
-            crate::Item::Table(v) => visitor.visit_map(crate::de::TableMapAccess::new(v)),
+            crate::Item::None => visitor.visit_none().map_err(|mut e: Self::Error| {
+                if e.span().is_none() {
+                    e.set_span(span);
+                }
+                e
+            }),
+            crate::Item::Value(v) => v.deserialize_any(visitor).map_err(|mut e: Self::Error| {
+                if e.span().is_none() {
+                    e.set_span(span);
+                }
+                e
+            }),
+            crate::Item::Table(v) => visitor
+                .visit_map(crate::de::TableMapAccess::new(v))
+                .map_err(|mut e: Self::Error| {
+                    if e.span().is_none() {
+                        e.set_span(span);
+                    }
+                    e
+                }),
             crate::Item::ArrayOfTables(v) => {
                 visitor.visit_seq(crate::de::ArraySeqAccess::with_array_of_tables(v))
             }
@@ -114,7 +140,13 @@ impl<'de> serde::Deserializer<'de> for crate::Item {
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_some(self)
+        let span = self.span();
+        visitor.visit_some(self).map_err(|mut e: Self::Error| {
+            if e.span().is_none() {
+                e.set_span(span);
+            }
+            e
+        })
     }
 
     fn deserialize_newtype_struct<V>(
@@ -125,7 +157,15 @@ impl<'de> serde::Deserializer<'de> for crate::Item {
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_newtype_struct(self)
+        let span = self.span();
+        visitor
+            .visit_newtype_struct(self)
+            .map_err(|mut e: Self::Error| {
+                if e.span().is_none() {
+                    e.set_span(span);
+                }
+                e
+            })
     }
 
     // Called when the type to deserialize is an enum, as opposed to a field in the type.
@@ -138,8 +178,17 @@ impl<'de> serde::Deserializer<'de> for crate::Item {
     where
         V: serde::de::Visitor<'de>,
     {
+        let span = self.span();
         match self {
-            crate::Item::Value(v) => v.deserialize_enum(name, variants, visitor),
+            crate::Item::Value(v) => {
+                v.deserialize_enum(name, variants, visitor)
+                    .map_err(|mut e: Self::Error| {
+                        if e.span().is_none() {
+                            e.set_span(span);
+                        }
+                        e
+                    })
+            }
             crate::Item::Table(v) => {
                 if v.is_empty() {
                     Err(crate::de::Error::custom(
@@ -152,7 +201,14 @@ impl<'de> serde::Deserializer<'de> for crate::Item {
                         v.span(),
                     ))
                 } else {
-                    visitor.visit_enum(crate::de::TableMapAccess::new(v))
+                    visitor
+                        .visit_enum(crate::de::TableMapAccess::new(v))
+                        .map_err(|mut e: Self::Error| {
+                            if e.span().is_none() {
+                                e.set_span(span);
+                            }
+                            e
+                        })
                 }
             }
             e => Err(crate::de::Error::custom("wanted string or table", e.span())),

--- a/crates/toml_edit/src/de/item.rs
+++ b/crates/toml_edit/src/de/item.rs
@@ -144,18 +144,18 @@ impl<'de> serde::Deserializer<'de> for crate::Item {
                 if v.is_empty() {
                     Err(crate::de::Error::custom(
                         "wanted exactly 1 element, found 0 elements",
-                        None,
+                        v.span(),
                     ))
                 } else if v.len() != 1 {
                     Err(crate::de::Error::custom(
                         "wanted exactly 1 element, more than 1 element",
-                        None,
+                        v.span(),
                     ))
                 } else {
                     visitor.visit_enum(crate::de::TableMapAccess::new(v))
                 }
             }
-            _ => Err(crate::de::Error::custom("wanted string or table", None)),
+            e => Err(crate::de::Error::custom("wanted string or table", e.span())),
         }
     }
 

--- a/crates/toml_edit/src/de/item.rs
+++ b/crates/toml_edit/src/de/item.rs
@@ -144,16 +144,18 @@ impl<'de> serde::Deserializer<'de> for crate::Item {
                 if v.is_empty() {
                     Err(crate::de::Error::custom(
                         "wanted exactly 1 element, found 0 elements",
+                        None,
                     ))
                 } else if v.len() != 1 {
                     Err(crate::de::Error::custom(
                         "wanted exactly 1 element, more than 1 element",
+                        None,
                     ))
                 } else {
                     visitor.visit_enum(crate::de::TableMapAccess::new(v))
                 }
             }
-            _ => Err(crate::de::Error::custom("wanted string or table")),
+            _ => Err(crate::de::Error::custom("wanted string or table", None)),
         }
     }
 

--- a/crates/toml_edit/src/de/mod.rs
+++ b/crates/toml_edit/src/de/mod.rs
@@ -106,7 +106,7 @@ impl From<crate::TomlError> for Error {
 
 impl From<Error> for crate::TomlError {
     fn from(e: Error) -> crate::TomlError {
-        Self::custom(e.to_string())
+        Self::custom(e.to_string(), e.span())
     }
 }
 

--- a/crates/toml_edit/src/de/mod.rs
+++ b/crates/toml_edit/src/de/mod.rs
@@ -59,6 +59,7 @@ impl Error {
     /// Produces a (line, column) pair of the position of the error if available
     ///
     /// All indexes are 0-based.
+    #[deprecated(since = "0.18.0", note = "See instead `TomlError::span`")]
     pub fn line_col(&self) -> Option<(usize, usize)> {
         self.inner.line_col
     }

--- a/crates/toml_edit/src/de/mod.rs
+++ b/crates/toml_edit/src/de/mod.rs
@@ -56,6 +56,10 @@ impl Error {
         self.inner.span.clone()
     }
 
+    pub(crate) fn set_span(&mut self, span: Option<std::ops::Range<usize>>) {
+        self.inner.span = span;
+    }
+
     /// Produces a (line, column) pair of the position of the error if available
     ///
     /// All indexes are 0-based.

--- a/crates/toml_edit/src/de/mod.rs
+++ b/crates/toml_edit/src/de/mod.rs
@@ -87,6 +87,7 @@ impl std::fmt::Display for Error {
 
 impl From<crate::TomlError> for Error {
     fn from(e: crate::TomlError) -> Error {
+        #[allow(deprecated)]
         let line_col = e.line_col();
         let mut err = Self::custom(e);
         err.inner.line_col = line_col;

--- a/crates/toml_edit/src/de/table.rs
+++ b/crates/toml_edit/src/de/table.rs
@@ -130,12 +130,7 @@ impl<'de> serde::de::MapAccess<'de> for TableMapAccess {
         V: serde::de::DeserializeSeed<'de>,
     {
         match self.value.take() {
-            Some((k, v)) => seed
-                .deserialize(crate::de::ItemDeserializer::new(v))
-                .map_err(|mut err| {
-                    err.parent_key(k);
-                    err
-                }),
+            Some((_k, v)) => seed.deserialize(crate::de::ItemDeserializer::new(v)),
             None => {
                 panic!("no more values in next_value_seed, internal error in ItemDeserializer")
             }

--- a/crates/toml_edit/src/de/table.rs
+++ b/crates/toml_edit/src/de/table.rs
@@ -57,12 +57,12 @@ impl<'de> serde::Deserializer<'de> for crate::Table {
         if self.is_empty() {
             Err(crate::de::Error::custom(
                 "wanted exactly 1 element, found 0 elements",
-                None,
+                self.span(),
             ))
         } else if self.len() != 1 {
             Err(crate::de::Error::custom(
                 "wanted exactly 1 element, more than 1 element",
-                None,
+                self.span(),
             ))
         } else {
             visitor.visit_enum(crate::de::TableMapAccess::new(self))
@@ -86,13 +86,16 @@ impl<'de> serde::de::IntoDeserializer<'de, crate::de::Error> for crate::Table {
 
 pub(crate) struct TableMapAccess {
     iter: indexmap::map::IntoIter<crate::InternalString, crate::table::TableKeyValue>,
+    span: Option<std::ops::Range<usize>>,
     value: Option<(crate::InternalString, crate::Item)>,
 }
 
 impl TableMapAccess {
     pub(crate) fn new(input: crate::Table) -> Self {
+        let span = input.span();
         Self {
             iter: input.items.into_iter(),
+            span,
             value: None,
         }
     }
@@ -146,7 +149,7 @@ impl<'de> serde::de::EnumAccess<'de> for TableMapAccess {
             None => {
                 return Err(Error::custom(
                     "expected table with exactly 1 entry, found empty table",
-                    None,
+                    self.span,
                 ));
             }
         };

--- a/crates/toml_edit/src/de/table.rs
+++ b/crates/toml_edit/src/de/table.rs
@@ -57,10 +57,12 @@ impl<'de> serde::Deserializer<'de> for crate::Table {
         if self.is_empty() {
             Err(crate::de::Error::custom(
                 "wanted exactly 1 element, found 0 elements",
+                None,
             ))
         } else if self.len() != 1 {
             Err(crate::de::Error::custom(
                 "wanted exactly 1 element, more than 1 element",
+                None,
             ))
         } else {
             visitor.visit_enum(crate::de::TableMapAccess::new(self))
@@ -144,6 +146,7 @@ impl<'de> serde::de::EnumAccess<'de> for TableMapAccess {
             None => {
                 return Err(Error::custom(
                     "expected table with exactly 1 entry, found empty table",
+                    None,
                 ));
             }
         };

--- a/crates/toml_edit/src/de/table.rs
+++ b/crates/toml_edit/src/de/table.rs
@@ -110,7 +110,14 @@ impl<'de> serde::de::MapAccess<'de> for TableMapAccess {
     {
         match self.iter.next() {
             Some((k, v)) => {
-                let ret = seed.deserialize(k.into_deserializer()).map(Some);
+                let ret = seed.deserialize(k.into_deserializer()).map(Some).map_err(
+                    |mut e: Self::Error| {
+                        if e.span().is_none() {
+                            e.set_span(v.key.span());
+                        }
+                        e
+                    },
+                );
                 self.value = Some((k, v.value));
                 ret
             }

--- a/crates/toml_edit/src/de/table_enum.rs
+++ b/crates/toml_edit/src/de/table_enum.rs
@@ -20,20 +20,20 @@ impl<'de> serde::de::VariantAccess<'de> for TableEnumDeserializer {
                 if values.is_empty() {
                     Ok(())
                 } else {
-                    Err(Error::custom("expected empty table"))
+                    Err(Error::custom("expected empty table", None))
                 }
             }
             crate::Item::Value(crate::Value::InlineTable(values)) => {
                 if values.is_empty() {
                     Ok(())
                 } else {
-                    Err(Error::custom("expected empty table"))
+                    Err(Error::custom("expected empty table", values.span()))
                 }
             }
-            e => Err(Error::custom(format!(
-                "expected table, found {}",
-                e.type_name()
-            ))),
+            e => Err(Error::custom(
+                format!("expected table, found {}", e.type_name()),
+                e.span(),
+            )),
         }
     }
 
@@ -51,15 +51,22 @@ impl<'de> serde::de::VariantAccess<'de> for TableEnumDeserializer {
         match self.value {
             crate::Item::Table(values) => {
                 let tuple_values = values
+                    .items
                     .into_iter()
                     .enumerate()
-                    .map(|(index, (key, value))| match key.parse::<usize>() {
-                        Ok(key_index) if key_index == index => Ok(value),
-                        Ok(_) | Err(_) => Err(Error::custom(format!(
-                            "expected table key `{}`, but was `{}`",
-                            index, key
-                        ))),
-                    })
+                    .map(
+                        |(index, (_, value))| match value.key.get().parse::<usize>() {
+                            Ok(key_index) if key_index == index => Ok(value.value),
+                            Ok(_) | Err(_) => Err(Error::custom(
+                                format!(
+                                    "expected table key `{}`, but was `{}`",
+                                    index,
+                                    value.key.get()
+                                ),
+                                value.key.span(),
+                            )),
+                        },
+                    )
                     // Fold all values into a `Vec`, or return the first error.
                     .fold(Ok(Vec::with_capacity(len)), |result, value_result| {
                         result.and_then(move |mut tuple_values| match value_result {
@@ -78,25 +85,36 @@ impl<'de> serde::de::VariantAccess<'de> for TableEnumDeserializer {
                         visitor,
                     )
                 } else {
-                    Err(Error::custom(format!("expected tuple with length {}", len)))
+                    Err(Error::custom(
+                        format!("expected tuple with length {}", len),
+                        None,
+                    ))
                 }
             }
             crate::Item::Value(crate::Value::InlineTable(values)) => {
+                let values_span = values.span();
                 let tuple_values = values
+                    .items
                     .into_iter()
                     .enumerate()
-                    .map(|(index, (key, value))| match key.parse::<usize>() {
-                        Ok(key_index) if key_index == index => Ok(value),
-                        Ok(_) | Err(_) => Err(Error::custom(format!(
-                            "expected table key `{}`, but was `{}`",
-                            index, key
-                        ))),
-                    })
+                    .map(
+                        |(index, (_, value))| match value.key.get().parse::<usize>() {
+                            Ok(key_index) if key_index == index => Ok(value.value),
+                            Ok(_) | Err(_) => Err(Error::custom(
+                                format!(
+                                    "expected table key `{}`, but was `{}`",
+                                    index,
+                                    value.key.get()
+                                ),
+                                value.key.span(),
+                            )),
+                        },
+                    )
                     // Fold all values into a `Vec`, or return the first error.
                     .fold(Ok(Vec::with_capacity(len)), |result, value_result| {
                         result.and_then(move |mut tuple_values| match value_result {
                             Ok(value) => {
-                                tuple_values.push(crate::Item::Value(value));
+                                tuple_values.push(value);
                                 Ok(tuple_values)
                             }
                             // `Result<de::Value, Self::Error>` to `Result<Vec<_>, Self::Error>`
@@ -110,13 +128,16 @@ impl<'de> serde::de::VariantAccess<'de> for TableEnumDeserializer {
                         visitor,
                     )
                 } else {
-                    Err(Error::custom(format!("expected tuple with length {}", len)))
+                    Err(Error::custom(
+                        format!("expected tuple with length {}", len),
+                        values_span,
+                    ))
                 }
             }
-            e => Err(Error::custom(format!(
-                "expected table, found {}",
-                e.type_name()
-            ))),
+            e => Err(Error::custom(
+                format!("expected table, found {}", e.type_name()),
+                e.span(),
+            )),
         }
     }
 

--- a/crates/toml_edit/src/de/table_enum.rs
+++ b/crates/toml_edit/src/de/table_enum.rs
@@ -20,7 +20,7 @@ impl<'de> serde::de::VariantAccess<'de> for TableEnumDeserializer {
                 if values.is_empty() {
                     Ok(())
                 } else {
-                    Err(Error::custom("expected empty table", None))
+                    Err(Error::custom("expected empty table", values.span()))
                 }
             }
             crate::Item::Value(crate::Value::InlineTable(values)) => {
@@ -50,6 +50,7 @@ impl<'de> serde::de::VariantAccess<'de> for TableEnumDeserializer {
     {
         match self.value {
             crate::Item::Table(values) => {
+                let values_span = values.span();
                 let tuple_values = values
                     .items
                     .into_iter()
@@ -87,7 +88,7 @@ impl<'de> serde::de::VariantAccess<'de> for TableEnumDeserializer {
                 } else {
                     Err(Error::custom(
                         format!("expected tuple with length {}", len),
-                        None,
+                        values_span,
                     ))
                 }
             }

--- a/crates/toml_edit/src/de/value.rs
+++ b/crates/toml_edit/src/de/value.rs
@@ -71,16 +71,21 @@ impl<'de> serde::Deserializer<'de> for crate::Value {
                 if v.is_empty() {
                     Err(crate::de::Error::custom(
                         "wanted exactly 1 element, found 0 elements",
+                        v.span(),
                     ))
                 } else if v.len() != 1 {
                     Err(crate::de::Error::custom(
                         "wanted exactly 1 element, more than 1 element",
+                        v.span(),
                     ))
                 } else {
                     visitor.visit_enum(crate::de::InlineTableMapAccess::new(v))
                 }
             }
-            _ => Err(crate::de::Error::custom("wanted string or inline table")),
+            _ => Err(crate::de::Error::custom(
+                "wanted string or inline table",
+                self.span(),
+            )),
         }
     }
 

--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -173,6 +173,12 @@ impl InlineTable {
         &self.preamble
     }
 
+    /// Returns the location within the original document
+    #[cfg(feature = "serde")]
+    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+        self.span.clone()
+    }
+
     pub(crate) fn despan(&mut self, input: &str) {
         self.span = None;
         self.decor.despan(input);

--- a/crates/toml_edit/src/item.rs
+++ b/crates/toml_edit/src/item.rs
@@ -296,6 +296,17 @@ impl Item {
         self.as_table_like().is_some()
     }
 
+    /// Returns the location within the original document
+    #[cfg(feature = "serde")]
+    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+        match self {
+            Item::None => None,
+            Item::Value(v) => v.span(),
+            Item::Table(_) => None,
+            Item::ArrayOfTables(_) => None,
+        }
+    }
+
     pub(crate) fn despan(&mut self, input: &str) {
         match self {
             Item::None => {}

--- a/crates/toml_edit/src/key.rs
+++ b/crates/toml_edit/src/key.rs
@@ -109,7 +109,6 @@ impl Key {
     }
 
     /// Returns the location within the original document
-    #[cfg(feature = "serde")]
     pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
         self.repr.as_ref().and_then(|r| r.span())
     }

--- a/crates/toml_edit/src/key.rs
+++ b/crates/toml_edit/src/key.rs
@@ -108,6 +108,12 @@ impl Key {
         &self.decor
     }
 
+    /// Returns the location within the original document
+    #[cfg(feature = "serde")]
+    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+        self.repr.as_ref().and_then(|r| r.span())
+    }
+
     pub(crate) fn despan(&mut self, input: &str) {
         self.decor.despan(input);
         if let Some(repr) = &mut self.repr {

--- a/crates/toml_edit/src/parser/errors.rs
+++ b/crates/toml_edit/src/parser/errors.rs
@@ -39,11 +39,11 @@ impl TomlError {
     }
 
     #[cfg(feature = "serde")]
-    pub(crate) fn custom(message: String) -> Self {
+    pub(crate) fn custom(message: String, span: Option<std::ops::Range<usize>>) -> Self {
         Self {
             message,
             original: None,
-            span: None,
+            span,
         }
     }
 

--- a/crates/toml_edit/src/parser/errors.rs
+++ b/crates/toml_edit/src/parser/errors.rs
@@ -61,6 +61,7 @@ impl TomlError {
     /// Produces a (line, column) pair of the position of the error if available
     ///
     /// All indexes are 0-based.
+    #[deprecated(since = "0.18.0", note = "See instead `TomlError::span`")]
     pub fn line_col(&self) -> Option<(usize, usize)> {
         if let (Some(original), Some(span)) = (&self.original, self.span()) {
             Some(translate_position(original.as_bytes(), span.start))

--- a/crates/toml_edit/src/parser/errors.rs
+++ b/crates/toml_edit/src/parser/errors.rs
@@ -119,7 +119,13 @@ impl Display for TomlError {
             for _ in 0..=column {
                 write!(f, " ")?;
             }
-            writeln!(f, "^")?;
+            // The span will be empty at eof, so we need to make sure we always print at least
+            // one `^`
+            write!(f, "^")?;
+            for _ in (span.start + 1)..(span.end.min(span.start + content.len())) {
+                write!(f, "^")?;
+            }
+            writeln!(f)?;
         }
         write!(f, "{}", self.message)?;
 

--- a/crates/toml_edit/src/parser/errors.rs
+++ b/crates/toml_edit/src/parser/errors.rs
@@ -52,6 +52,16 @@ impl TomlError {
         self.span.clone()
     }
 
+    #[cfg(feature = "serde")]
+    pub(crate) fn set_span(&mut self, span: Option<std::ops::Range<usize>>) {
+        self.span = span;
+    }
+
+    #[cfg(feature = "serde")]
+    pub(crate) fn set_original(&mut self, original: Option<String>) {
+        self.original = original;
+    }
+
     /// Produces a (line, column) pair of the position of the error if available
     ///
     /// All indexes are 0-based.

--- a/crates/toml_edit/src/parser/state.rs
+++ b/crates/toml_edit/src/parser/state.rs
@@ -114,6 +114,7 @@ impl ParseState {
         self.current_table_position += 1;
         self.current_table.decor = decor;
         self.current_table.set_position(self.current_table_position);
+        self.current_table.span = path.last().unwrap().span();
         self.current_is_array = true;
         self.current_table_path = path;
 
@@ -143,6 +144,7 @@ impl ParseState {
         self.current_table_position += 1;
         self.current_table.decor = decor;
         self.current_table.set_position(self.current_table_position);
+        self.current_table.span = path.last().unwrap().span();
         self.current_is_array = false;
         self.current_table_path = path;
 

--- a/crates/toml_edit/src/repr.rs
+++ b/crates/toml_edit/src/repr.rs
@@ -58,6 +58,12 @@ where
             })
     }
 
+    /// Returns the location within the original document
+    #[cfg(feature = "serde")]
+    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+        self.repr.as_ref().and_then(|r| r.span())
+    }
+
     pub(crate) fn despan(&mut self, input: &str) {
         self.decor.despan(input);
         if let Some(repr) = &mut self.repr {
@@ -111,6 +117,12 @@ impl Repr {
     /// Access the underlying value
     pub fn as_raw(&self) -> &RawString {
         &self.raw_value
+    }
+
+    /// Returns the location within the original document
+    #[cfg(feature = "serde")]
+    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+        self.raw_value.span()
     }
 
     pub(crate) fn despan(&mut self, input: &str) {

--- a/crates/toml_edit/src/repr.rs
+++ b/crates/toml_edit/src/repr.rs
@@ -120,7 +120,6 @@ impl Repr {
     }
 
     /// Returns the location within the original document
-    #[cfg(feature = "serde")]
     pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
         self.raw_value.span()
     }

--- a/crates/toml_edit/src/ser/mod.rs
+++ b/crates/toml_edit/src/ser/mod.rs
@@ -55,7 +55,7 @@ impl From<crate::TomlError> for Error {
 
 impl From<Error> for crate::TomlError {
     fn from(e: Error) -> crate::TomlError {
-        Self::custom(e.to_string())
+        Self::custom(e.to_string(), None)
     }
 }
 

--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -21,6 +21,7 @@ pub struct Table {
     // `None` for user created tables (can be overridden with `set_position`)
     doc_position: Option<usize>,
     pub(crate) items: KeyValuePairs,
+    pub(crate) span: Option<std::ops::Range<usize>>,
 }
 
 /// Constructors
@@ -223,7 +224,14 @@ impl Table {
         self.items.get(key).map(|kv| &kv.key.decor)
     }
 
+    /// Returns the location within the original document
+    #[cfg(feature = "serde")]
+    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+        self.span.clone()
+    }
+
     pub(crate) fn despan(&mut self, input: &str) {
+        self.span = None;
         for kv in self.items.values_mut() {
             kv.key.despan(input);
             kv.value.despan(input);

--- a/crates/toml_edit/src/value.rs
+++ b/crates/toml_edit/src/value.rs
@@ -205,6 +205,20 @@ impl Value {
         *decor = Decor::new(prefix, suffix);
     }
 
+    /// Returns the location within the original document
+    #[cfg(feature = "serde")]
+    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+        match self {
+            Value::String(f) => f.span(),
+            Value::Integer(f) => f.span(),
+            Value::Float(f) => f.span(),
+            Value::Boolean(f) => f.span(),
+            Value::Datetime(f) => f.span(),
+            Value::Array(a) => a.span(),
+            Value::InlineTable(t) => t.span(),
+        }
+    }
+
     pub(crate) fn despan(&mut self, input: &str) {
         match self {
             Value::String(f) => f.despan(input),

--- a/crates/toml_edit/tests/testsuite/enum_external_deserialize.rs
+++ b/crates/toml_edit/tests/testsuite/enum_external_deserialize.rs
@@ -32,7 +32,11 @@ fn invalid_variant_returns_error_with_good_message_string() {
 
     snapbox::assert_eq(
         error.to_string(),
-        "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct` for key `val`"
+        r#"TOML parse error at line 1, column 7
+  |
+1 | val = "NonExistent"
+  |       ^
+unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"#,
     );
 }
 
@@ -41,7 +45,11 @@ fn invalid_variant_returns_error_with_good_message_inline_table() {
     let error = toml::from_str::<Val>("val = { NonExistent = {} }").unwrap_err();
     snapbox::assert_eq(
         error.to_string(),
-        "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct` for key `val`"
+        r#"TOML parse error at line 1, column 9
+  |
+1 | val = { NonExistent = {} }
+  |         ^
+unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"#,
     );
 }
 
@@ -49,7 +57,14 @@ fn invalid_variant_returns_error_with_good_message_inline_table() {
 fn extra_field_returns_expected_empty_table_error() {
     let error = toml::from_str::<Val>("val = { Plain = { extra_field = 404 } }").unwrap_err();
 
-    snapbox::assert_eq(error.to_string(), "expected empty table for key `val`");
+    snapbox::assert_eq(
+        error.to_string(),
+        r#"TOML parse error at line 1, column 17
+  |
+1 | val = { Plain = { extra_field = 404 } }
+  |                 ^
+expected empty table"#,
+    );
 }
 
 #[test]
@@ -60,7 +75,11 @@ fn extra_field_returns_expected_empty_table_error_struct_variant() {
 
     snapbox::assert_eq(
         error.to_string(),
-        r#"unexpected keys in table: extra_0, extra_1, available keys: value for key `val`"#,
+        r#"TOML parse error at line 1, column 33
+  |
+1 | val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }
+  |                                 ^
+unexpected keys in table: extra_0, extra_1, available keys: value"#,
     );
 }
 

--- a/crates/toml_edit/tests/testsuite/enum_external_deserialize.rs
+++ b/crates/toml_edit/tests/testsuite/enum_external_deserialize.rs
@@ -30,7 +30,7 @@ struct Multi {
 fn invalid_variant_returns_error_with_good_message_string() {
     let error = toml::from_str::<Val>("val = \"NonExistent\"").unwrap_err();
 
-    assert_eq!(
+    snapbox::assert_eq(
         error.to_string(),
         "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct` for key `val`"
     );
@@ -39,7 +39,7 @@ fn invalid_variant_returns_error_with_good_message_string() {
 #[test]
 fn invalid_variant_returns_error_with_good_message_inline_table() {
     let error = toml::from_str::<Val>("val = { NonExistent = {} }").unwrap_err();
-    assert_eq!(
+    snapbox::assert_eq(
         error.to_string(),
         "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct` for key `val`"
     );
@@ -49,7 +49,7 @@ fn invalid_variant_returns_error_with_good_message_inline_table() {
 fn extra_field_returns_expected_empty_table_error() {
     let error = toml::from_str::<Val>("val = { Plain = { extra_field = 404 } }").unwrap_err();
 
-    assert_eq!(error.to_string(), "expected empty table for key `val`");
+    snapbox::assert_eq(error.to_string(), "expected empty table for key `val`");
 }
 
 #[test]
@@ -58,9 +58,9 @@ fn extra_field_returns_expected_empty_table_error_struct_variant() {
         toml::from_str::<Val>("val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }")
             .unwrap_err();
 
-    assert_eq!(
+    snapbox::assert_eq(
         error.to_string(),
-        r#"unexpected keys in table: extra_0, extra_1, available keys: value for key `val`"#
+        r#"unexpected keys in table: extra_0, extra_1, available keys: value for key `val`"#,
     );
 }
 

--- a/crates/toml_edit/tests/testsuite/enum_external_deserialize.rs
+++ b/crates/toml_edit/tests/testsuite/enum_external_deserialize.rs
@@ -35,7 +35,7 @@ fn invalid_variant_returns_error_with_good_message_string() {
         r#"TOML parse error at line 1, column 7
   |
 1 | val = "NonExistent"
-  |       ^
+  |       ^^^^^^^^^^^^^
 unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"#,
     );
 }
@@ -48,7 +48,7 @@ fn invalid_variant_returns_error_with_good_message_inline_table() {
         r#"TOML parse error at line 1, column 9
   |
 1 | val = { NonExistent = {} }
-  |         ^
+  |         ^^^^^^^^^^^
 unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"#,
     );
 }
@@ -62,7 +62,7 @@ fn extra_field_returns_expected_empty_table_error() {
         r#"TOML parse error at line 1, column 17
   |
 1 | val = { Plain = { extra_field = 404 } }
-  |                 ^
+  |                 ^^^^^^^^^^^^^^^^^^^^^
 expected empty table"#,
     );
 }
@@ -78,7 +78,7 @@ fn extra_field_returns_expected_empty_table_error_struct_variant() {
         r#"TOML parse error at line 1, column 33
   |
 1 | val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }
-  |                                 ^
+  |                                 ^^^^^^^
 unexpected keys in table: extra_0, extra_1, available keys: value"#,
     );
 }

--- a/crates/toml_edit/tests/testsuite/serde.rs
+++ b/crates/toml_edit/tests/testsuite/serde.rs
@@ -218,8 +218,12 @@ fn type_errors() {
         Table(map! {
             bar: Value::String("a".to_string())
         }),
-        "invalid type: string \"a\", expected isize for key `bar`",
-        "invalid type: string \"a\", expected isize for key `bar`"
+        r#"TOML parse error at line 1, column 7
+  |
+1 | bar = "a"
+  |       ^
+invalid type: string "a", expected isize"#,
+        "invalid type: string \"a\", expected isize"
     }
 
     #[derive(Deserialize)]
@@ -235,8 +239,12 @@ fn type_errors() {
                 bar: Value::String("a".to_string())
             })
         }),
-        "invalid type: string \"a\", expected isize for key `foo.bar`",
-        "invalid type: string \"a\", expected isize for key `foo.bar`"
+        r#"TOML parse error at line 2, column 7
+  |
+2 | bar = "a"
+  |       ^
+invalid type: string "a", expected isize"#,
+        "invalid type: string \"a\", expected isize"
     }
 }
 
@@ -536,10 +544,7 @@ debug = 'a'
 "#,
     );
     let err = res.unwrap_err();
-    snapbox::assert_eq(
-        err.to_string(),
-        "expected a boolean or an integer for key `profile.dev.debug`",
-    );
+    snapbox::assert_eq(err.to_string(), "expected a boolean or an integer");
 
     let res: Result<Package, _> = toml_edit::de::from_str(
         r#"
@@ -555,7 +560,11 @@ dev = { debug = 'a' }
     let err = res.unwrap_err();
     snapbox::assert_eq(
         err.to_string(),
-        "expected a boolean or an integer for key `profile.dev.debug`",
+        r#"TOML parse error at line 8, column 17
+  |
+8 | dev = { debug = 'a' }
+  |                 ^
+expected a boolean or an integer"#,
     );
 }
 

--- a/crates/toml_edit/tests/testsuite/serde.rs
+++ b/crates/toml_edit/tests/testsuite/serde.rs
@@ -30,14 +30,14 @@ macro_rules! equivalent {
 
         // Through a string equivalent
         println!("to_string(literal)");
-        assert_eq!(
+        snapbox::assert_eq(
             t!(toml_edit::easy::to_string_pretty(&literal)),
-            toml.to_string()
+            toml.to_string(),
         );
         println!("to_string(toml)");
-        assert_eq!(
+        snapbox::assert_eq(
             t!(toml_edit::easy::to_string_pretty(&toml)),
-            toml.to_string()
+            toml.to_string(),
         );
         println!("literal, from_str(toml)");
         assert_eq!(literal, t!(toml_edit::easy::from_str(&toml.to_string())));
@@ -51,13 +51,13 @@ macro_rules! error {
         println!("attempting parsing");
         match toml_edit::easy::from_str::<$ty>(&$toml.to_string()) {
             Ok(_) => panic!("successful"),
-            Err(e) => assert_eq!(e.to_string(), $msg_parse),
+            Err(e) => snapbox::assert_eq(e.to_string(), $msg_parse),
         }
 
         println!("attempting toml decoding");
         match $toml.try_into::<$ty>() {
             Ok(_) => panic!("successful"),
-            Err(e) => assert_eq!(e.to_string(), $msg_decode),
+            Err(e) => snapbox::assert_eq(e.to_string(), $msg_decode),
         }
     }};
 }
@@ -442,7 +442,7 @@ fn table_structs_empty() {
     );
     expected.insert("foo".to_string(), CanBeEmpty::default());
     assert_eq!(value, expected);
-    assert_eq!(toml_edit::ser::to_string(&value).unwrap(), text);
+    snapbox::assert_eq(toml_edit::ser::to_string(&value).unwrap(), text);
 }
 
 #[test]
@@ -536,9 +536,9 @@ debug = 'a'
 "#,
     );
     let err = res.unwrap_err();
-    assert_eq!(
+    snapbox::assert_eq(
         err.to_string(),
-        "expected a boolean or an integer for key `profile.dev.debug`"
+        "expected a boolean or an integer for key `profile.dev.debug`",
     );
 
     let res: Result<Package, _> = toml_edit::de::from_str(
@@ -553,9 +553,9 @@ dev = { debug = 'a' }
 "#,
     );
     let err = res.unwrap_err();
-    assert_eq!(
+    snapbox::assert_eq(
         err.to_string(),
-        "expected a boolean or an integer for key `profile.dev.debug`"
+        "expected a boolean or an integer for key `profile.dev.debug`",
     );
 }
 

--- a/crates/toml_edit/tests/testsuite/serde.rs
+++ b/crates/toml_edit/tests/testsuite/serde.rs
@@ -221,7 +221,7 @@ fn type_errors() {
         r#"TOML parse error at line 1, column 7
   |
 1 | bar = "a"
-  |       ^
+  |       ^^^
 invalid type: string "a", expected isize"#,
         "invalid type: string \"a\", expected isize"
     }
@@ -242,7 +242,7 @@ invalid type: string "a", expected isize"#,
         r#"TOML parse error at line 2, column 7
   |
 2 | bar = "a"
-  |       ^
+  |       ^^^
 invalid type: string "a", expected isize"#,
         "invalid type: string \"a\", expected isize"
     }
@@ -563,7 +563,7 @@ dev = { debug = 'a' }
         r#"TOML parse error at line 8, column 17
   |
 8 | dev = { debug = 'a' }
-  |                 ^
+  |                 ^^^
 expected a boolean or an integer"#,
     );
 }


### PR DESCRIPTION
The caller can ask for the span and we report it in the error messages.  This does come with a regression when an error does not originate from a toml string.

This had no discernible performance impact.

Fixes #303