### PR TITLE
doc(toml): Simplify upgrade path

### DIFF
--- a/crates/toml/src/ser.rs
+++ b/crates/toml/src/ser.rs
@@ -152,6 +152,51 @@ impl<'d> Serializer<'d> {
         ser.settings.multiline_array = true;
         ser
     }
+
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.6.0",
+        note = "string behavior is now automatic; for greater control deserialize to `toml_edit::Document` and use `toml_edit::visit_mut::VisitorMut`"
+    )]
+    pub fn pretty_string(&mut self, _value: bool) -> &mut Self {
+        self
+    }
+
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.6.0",
+        note = "string behavior is now automatic; for greater control deserialize to `toml_edit::Document` and use `toml_edit::visit_mut::VisitorMut`"
+    )]
+    pub fn pretty_string_literal(&mut self, _value: bool) -> &mut Self {
+        self
+    }
+
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.6.0",
+        note = "this is bundled in with `pretty`; for greater control deserialize to `toml_edit::Document` and use `toml_edit::visit_mut::VisitorMut`"
+    )]
+    pub fn pretty_array(&mut self, _value: bool) -> &mut Self {
+        self
+    }
+
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.6.0",
+        note = "this is bundled in with `pretty`; for greater control deserialize to `toml_edit::Document` and use `toml_edit::visit_mut::VisitorMut`"
+    )]
+    pub fn pretty_array_indent(&mut self, _value: usize) -> &mut Self {
+        self
+    }
+
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.6.0",
+        note = "this is bundled in with `pretty`; for greater control deserialize to `toml_edit::Document` and use `toml_edit::visit_mut::VisitorMut`"
+    )]
+    pub fn pretty_array_trailing_comma(&mut self, _value: bool) -> &mut Self {
+        self
+    }
 }
 
 impl<'d> serde::ser::Serializer for Serializer<'d> {
@@ -1019,4 +1064,25 @@ fn write_value(
     write!(dst, "{}", value).unwrap();
 
     Ok(())
+}
+
+#[doc(hidden)]
+#[deprecated(
+    since = "0.6.0",
+    note = "`tables_last` is no longer needed; things just work"
+)]
+pub fn tables_last<'a, I, K, V, S>(data: &'a I, serializer: S) -> Result<S::Ok, S::Error>
+where
+    &'a I: IntoIterator<Item = (K, V)>,
+    K: serde::ser::Serialize,
+    V: serde::ser::Serialize,
+    S: serde::ser::Serializer,
+{
+    use serde::ser::SerializeMap;
+
+    let mut map = serializer.serialize_map(None)?;
+    for (k, v) in data {
+        map.serialize_entry(&k, &v)?;
+    }
+    map.end()
 }


### PR DESCRIPTION
This is a follow up to #470.  We can remove these in the next breaking release.