### PR TITLE
fix(de): Track the keys as an alternative to spans

### DIFF
--- a/crates/toml/src/de.rs
+++ b/crates/toml/src/de.rs
@@ -53,6 +53,10 @@ impl Error {
         Self { inner }
     }
 
+    pub(crate) fn add_key(&mut self, key: String) {
+        self.inner.add_key(key)
+    }
+
     /// What went wrong
     pub fn message(&self) -> &str {
         self.inner.message()

--- a/crates/toml/src/value.rs
+++ b/crates/toml/src/value.rs
@@ -797,11 +797,14 @@ impl<'de> de::MapAccess<'de> for MapDeserializer {
     where
         T: de::DeserializeSeed<'de>,
     {
-        let (_key, res) = match self.value.take() {
+        let (key, res) = match self.value.take() {
             Some((key, value)) => (key, seed.deserialize(value)),
             None => return Err(de::Error::custom("value is missing")),
         };
-        res
+        res.map_err(|mut error| {
+            error.add_key(key);
+            error
+        })
     }
 
     fn size_hint(&self) -> Option<usize> {

--- a/crates/toml/tests/testsuite/serde.rs
+++ b/crates/toml/tests/testsuite/serde.rs
@@ -276,7 +276,7 @@ fn type_errors() {
   |       ^^^
 invalid type: string "a", expected isize
 "#,
-        "invalid type: string \"a\", expected isize\n"
+        "invalid type: string \"a\", expected isize\nin `bar`\n"
     }
 
     #[derive(Deserialize)]
@@ -298,7 +298,7 @@ invalid type: string "a", expected isize
   |       ^^^
 invalid type: string "a", expected isize
 "#,
-        "invalid type: string \"a\", expected isize\n"
+        "invalid type: string \"a\", expected isize\nin `foo.bar`\n"
     }
 }
 

--- a/crates/toml_edit/src/de/mod.rs
+++ b/crates/toml_edit/src/de/mod.rs
@@ -38,6 +38,11 @@ impl Error {
         }
     }
 
+    /// Add key while unwinding
+    pub fn add_key(&mut self, key: String) {
+        self.inner.add_key(key)
+    }
+
     /// What went wrong
     pub fn message(&self) -> &str {
         self.inner.message()


### PR DESCRIPTION
When adding spans, the loss of key tracking was fine as that was covered by the span.  In testing this in cargo, I found there were too many cases where spans were removed (e.g. config subsystem converting to `toml::Value` and then converting to desired type), so adding it back in.