### PR TITLE
feat(toml): Make `toml_edit` optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
       run: cargo test -p toml_edit --no-default-features
     - name: toml (preserve_order)
       run: cargo test -p toml --features preserve_order
+    - name: toml (all features)
+      run: cargo test -p toml --all-features
+    - name: toml (parse-only)
+      run: cargo test -p toml --no-default-features --features parse
+    - name: toml (display-only)
+      run: cargo test -p toml --no-default-features --features display
+    - name: toml (no-default features)
+      run: cargo test -p toml --no-default-features
   msrv:
     name: "Check MSRV: 1.60.0"
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,16 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
 dependencies = [
  "indexmap",
  "serde",
@@ -908,15 +917,6 @@ dependencies = [
  "toml-test-harness",
  "toml_datetime",
  "toml_edit",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -960,7 +960,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml 0.5.10",
- "toml 0.5.9",
+ "toml 0.5.11",
  "toml_edit",
 ]
 

--- a/crates/toml/Cargo.toml
+++ b/crates/toml/Cargo.toml
@@ -36,7 +36,9 @@ pre-release-replacements = [
 ]
 
 [features]
-default = []
+default = ["parse", "display"]
+parse = ["dep:toml_edit"]
+display = ["dep:toml_edit"]
 
 # Use indexmap rather than BTreeMap as the map type of toml::Value.
 # This allows data to be read into a Value and written back to a TOML string
@@ -46,7 +48,7 @@ preserve_order = ["indexmap"]
 [dependencies]
 serde = "1.0.145"
 indexmap = { version = "1.9.1", optional = true }
-toml_edit = { version = "0.17.1", path = "../toml_edit", features = ["serde"] }
+toml_edit = { version = "0.17.1", path = "../toml_edit", features = ["serde"], optional = true }
 toml_datetime = { version = "0.5.1", path = "../toml_datetime", features = ["serde"] }
 serde_spanned = { version = "0.6.0", path = "../serde_spanned", features = ["serde"] }
 
@@ -63,3 +65,15 @@ harness = false
 [[test]]
 name = "encoder_compliance"
 harness = false
+
+[[example]]
+name = "decode"
+required-features = ["parse", "derive"]
+
+[[example]]
+name = "enum_external"
+required-features = ["parse", "derive"]
+
+[[example]]
+name = "toml2json"
+required-features = ["parse", "derive"]

--- a/crates/toml/src/de.rs
+++ b/crates/toml/src/de.rs
@@ -35,6 +35,7 @@
 /// assert_eq!(config.title, "TOML Example");
 /// assert_eq!(config.owner.name, "Lisa");
 /// ```
+#[cfg(feature = "parse")]
 pub fn from_str<T>(s: &'_ str) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,
@@ -45,11 +46,11 @@ where
 /// Errors that can occur when deserializing a type.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Error {
-    inner: toml_edit::de::Error,
+    inner: crate::edit::de::Error,
 }
 
 impl Error {
-    fn new(inner: toml_edit::de::Error) -> Self {
+    fn new(inner: crate::edit::de::Error) -> Self {
         Self { inner }
     }
 
@@ -63,6 +64,7 @@ impl Error {
     }
 
     /// The start/end index into the original document where the error occurred
+    #[cfg(feature = "parse")]
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.inner.span()
     }
@@ -71,6 +73,7 @@ impl Error {
     ///
     /// All indexes are 0-based.
     #[deprecated(since = "0.18.0", note = "See instead `Error::span`")]
+    #[cfg(feature = "parse")]
     pub fn line_col(&self) -> Option<(usize, usize)> {
         #[allow(deprecated)]
         self.inner.line_col()
@@ -82,7 +85,7 @@ impl serde::de::Error for Error {
     where
         T: std::fmt::Display,
     {
-        Error::new(toml_edit::de::Error::custom(msg))
+        Error::new(crate::edit::de::Error::custom(msg))
     }
 }
 
@@ -95,10 +98,12 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {}
 
 /// Deserialization TOML document
+#[cfg(feature = "parse")]
 pub struct Deserializer<'a> {
     input: &'a str,
 }
 
+#[cfg(feature = "parse")]
 impl<'a> Deserializer<'a> {
     /// Deserialization implementation for TOML.
     pub fn new(input: &'a str) -> Self {
@@ -106,6 +111,7 @@ impl<'a> Deserializer<'a> {
     }
 }
 
+#[cfg(feature = "parse")]
 impl<'de, 'a> serde::Deserializer<'de> for Deserializer<'a> {
     type Error = Error;
 
@@ -195,10 +201,12 @@ impl<'de, 'a> serde::Deserializer<'de> for Deserializer<'a> {
 }
 
 /// Deserialization TOML value
+#[cfg(feature = "parse")]
 pub struct ValueDeserializer<'a> {
     input: &'a str,
 }
 
+#[cfg(feature = "parse")]
 impl<'a> ValueDeserializer<'a> {
     /// Deserialization implementation for TOML.
     pub fn new(input: &'a str) -> Self {
@@ -206,6 +214,7 @@ impl<'a> ValueDeserializer<'a> {
     }
 }
 
+#[cfg(feature = "parse")]
 impl<'de, 'a> serde::Deserializer<'de> for ValueDeserializer<'a> {
     type Error = Error;
 

--- a/crates/toml/src/edit.rs
+++ b/crates/toml/src/edit.rs
@@ -1,0 +1,91 @@
+#[cfg(feature = "parse")]
+pub(crate) mod de {
+    pub(crate) use toml_edit::de::Error;
+}
+
+#[cfg(not(feature = "parse"))]
+pub(crate) mod de {
+    /// Errors that can occur when deserializing a type.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct Error {
+        inner: String,
+    }
+
+    impl Error {
+        /// Add key while unwinding
+        pub fn add_key(&mut self, _key: String) {}
+
+        /// What went wrong
+        pub fn message(&self) -> &str {
+            self.inner.as_str()
+        }
+    }
+
+    impl serde::de::Error for Error {
+        fn custom<T>(msg: T) -> Self
+        where
+            T: std::fmt::Display,
+        {
+            Error {
+                inner: msg.to_string(),
+            }
+        }
+    }
+
+    impl std::fmt::Display for Error {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.inner.fmt(f)
+        }
+    }
+
+    impl std::error::Error for Error {}
+}
+
+#[cfg(feature = "display")]
+pub(crate) mod ser {
+    pub(crate) use toml_edit::ser::Error;
+}
+
+#[cfg(not(feature = "display"))]
+pub(crate) mod ser {
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub(crate) enum Error {
+        UnsupportedType(Option<&'static str>),
+        UnsupportedNone,
+        KeyNotString,
+        Custom(String),
+    }
+
+    impl Error {
+        pub(crate) fn custom<T>(msg: T) -> Self
+        where
+            T: std::fmt::Display,
+        {
+            Error::Custom(msg.to_string())
+        }
+    }
+
+    impl serde::ser::Error for Error {
+        fn custom<T>(msg: T) -> Self
+        where
+            T: std::fmt::Display,
+        {
+            Self::custom(msg)
+        }
+    }
+
+    impl std::fmt::Display for Error {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::UnsupportedType(Some(t)) => write!(formatter, "unsupported {t} type"),
+                Self::UnsupportedType(None) => write!(formatter, "unsupported rust type"),
+                Self::UnsupportedNone => "unsupported None value".fmt(formatter),
+                Self::KeyNotString => "map key was not a string".fmt(formatter),
+                Self::Custom(s) => s.fmt(formatter),
+            }
+        }
+    }
+
+    impl std::error::Error for Error {}
+}

--- a/crates/toml/src/lib.rs
+++ b/crates/toml/src/lib.rs
@@ -35,7 +35,8 @@
 //!
 //! The easiest way to parse a TOML document is via the [`Table`] type:
 //!
-//! ```rust
+#![cfg_attr(not(feature = "parse"), doc = " ```ignore")]
+#![cfg_attr(feature = "parse", doc = " ```")]
 //! use toml::Table;
 //!
 //! let value = "foo = 'bar'".parse::<Table>().unwrap();
@@ -71,7 +72,8 @@
 //!
 //! An example of deserializing with TOML is:
 //!
-//! ```rust
+#![cfg_attr(not(feature = "parse"), doc = " ```ignore")]
+#![cfg_attr(feature = "parse", doc = " ```")]
 //! use serde::Deserialize;
 //!
 //! #[derive(Deserialize)]
@@ -103,7 +105,8 @@
 //!
 //! You can serialize types in a similar fashion:
 //!
-//! ```rust
+#![cfg_attr(not(feature = "display"), doc = " ```ignore")]
+#![cfg_attr(feature = "display", doc = " ```")]
 //! use serde::Serialize;
 //!
 //! #[derive(Serialize)]
@@ -153,15 +156,20 @@ pub use crate::value::Value;
 
 pub mod ser;
 #[doc(no_inline)]
+#[cfg(feature = "display")]
 pub use crate::ser::{to_string, to_string_pretty, Serializer};
 pub mod de;
 #[doc(no_inline)]
+#[cfg(feature = "parse")]
 pub use crate::de::{from_str, Deserializer, ValueDeserializer};
 
 #[doc(hidden)]
 pub mod macros;
 
+#[cfg(feature = "display")]
 mod fmt;
+
+mod edit;
 
 pub use serde_spanned::Spanned;
 

--- a/crates/toml/src/value.rs
+++ b/crates/toml/src/value.rs
@@ -5,7 +5,6 @@ use std::fmt;
 use std::hash::Hash;
 use std::mem::discriminant;
 use std::ops;
-use std::str::FromStr;
 use std::vec;
 
 use serde::de;
@@ -49,6 +48,7 @@ impl Table {
     }
 }
 
+#[cfg(feature = "display")]
 impl fmt::Display for Table {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::ser::to_string(self)
@@ -57,7 +57,8 @@ impl fmt::Display for Table {
     }
 }
 
-impl FromStr for Table {
+#[cfg(feature = "parse")]
+impl std::str::FromStr for Table {
     type Err = crate::de::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         crate::from_str(s)
@@ -480,6 +481,7 @@ where
     }
 }
 
+#[cfg(feature = "display")]
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use serde::Serialize as _;
@@ -491,7 +493,8 @@ impl fmt::Display for Value {
     }
 }
 
-impl FromStr for Value {
+#[cfg(feature = "parse")]
+impl std::str::FromStr for Value {
     type Err = crate::de::Error;
     fn from_str(s: &str) -> Result<Value, Self::Err> {
         crate::from_str(s)
@@ -1282,7 +1285,7 @@ impl ser::SerializeMap for SerializeMap {
                 self.map.insert(key, value);
             }
             Err(crate::ser::Error {
-                inner: toml_edit::ser::Error::UnsupportedNone,
+                inner: crate::edit::ser::Error::UnsupportedNone,
             }) => {}
             Err(e) => return Err(e),
         }

--- a/crates/toml/tests/decoder.rs
+++ b/crates/toml/tests/decoder.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "parse", feature = "display"))]
+
 #[derive(Copy, Clone)]
 pub struct Decoder;
 

--- a/crates/toml/tests/decoder_compliance.rs
+++ b/crates/toml/tests/decoder_compliance.rs
@@ -1,5 +1,6 @@
 mod decoder;
 
+#[cfg(all(feature = "parse", feature = "display"))]
 fn main() {
     let decoder = decoder::Decoder;
     let mut harness = toml_test_harness::DecoderHarness::new(decoder);
@@ -15,3 +16,6 @@ fn main() {
         .unwrap();
     harness.test();
 }
+
+#[cfg(not(all(feature = "parse", feature = "display")))]
+fn main() {}

--- a/crates/toml/tests/encoder.rs
+++ b/crates/toml/tests/encoder.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "parse", feature = "display"))]
+
 #[derive(Copy, Clone)]
 pub struct Encoder;
 

--- a/crates/toml/tests/encoder_compliance.rs
+++ b/crates/toml/tests/encoder_compliance.rs
@@ -1,6 +1,7 @@
 mod decoder;
 mod encoder;
 
+#[cfg(all(feature = "parse", feature = "display"))]
 fn main() {
     let encoder = encoder::Encoder;
     let decoder = decoder::Decoder;
@@ -8,3 +9,6 @@ fn main() {
     harness.ignore(["valid/spec/float-0.toml"]).unwrap();
     harness.test();
 }
+
+#[cfg(not(all(feature = "parse", feature = "display")))]
+fn main() {}

--- a/crates/toml/tests/testsuite/main.rs
+++ b/crates/toml/tests/testsuite/main.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "256"]
+#![cfg(all(feature = "parse", feature = "display"))]
 
 mod de_errors;
 mod display;


### PR DESCRIPTION
This is mostly targeting cases like `cargo_metadata`.

Both features pull in all of `toml_edit` for now but if this proves popular enough we can add features to `toml_edit` for these two halves.