### PR TITLE
Add a failing test for borrowed struct

### DIFF
--- a/crates/toml/tests/testsuite/serde.rs
+++ b/crates/toml/tests/testsuite/serde.rs
@@ -1050,3 +1050,15 @@ fn serialize_datetime_issue_333() {
     .unwrap();
     assert_eq!(toml, "date = 2022-01-01\n");
 }
+
+#[test]
+fn deserialize_borrowed_struct() {
+    #[derive(Deserialize)]
+    struct Config<'config> {
+        name: &'config str,
+    }
+    let config = r#"
+        name = "toml-rs"
+    "#;
+    assert!(toml::from_str::<Config>(config).is_ok());
+}


### PR DESCRIPTION
Minimal repro of a pattern that used to work on 0.5.11 but fails on the newly released 0.6.0

Code: https://github.com/msfjarvis/clipboard-substitutor/blob/2902495dd6046bb88dba0a001a35516d85d72400/src/config.rs
Build failure log: https://garnix.io/build/493mKXj0
