### PR TITLE
Turn off serde "derive" feature

### DIFF
--- a/crates/toml_edit/Cargo.toml
+++ b/crates/toml_edit/Cargo.toml
@@ -49,7 +49,7 @@ unbounded = []
 [dependencies]
 indexmap = "1.9.1"
 nom8 = "0.2.0"
-serde = { version = "1.0.145", features = ["derive"], optional = true }
+serde = { version = "1.0.145", optional = true }
 kstring = { version = "2.0.0", features = ["max_inline"], optional = true }
 toml_datetime = { version = "0.5.1", path = "../toml_datetime" }
 serde_spanned = { version = "0.6.0", path = "../serde_spanned", features = ["serde"], optional = true }

--- a/crates/toml_edit/src/easy/value.rs
+++ b/crates/toml_edit/src/easy/value.rs
@@ -16,8 +16,7 @@ pub use crate::easy::map::Map;
 
 #[doc(hidden)]
 #[deprecated(since = "0.18.0", note = "Replaced with `toml::Value`")]
-#[derive(PartialEq, Clone, Debug, serde::Serialize)]
-#[serde(untagged)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum Value {
     /// Represents a TOML integer
     Integer(i64),
@@ -399,6 +398,23 @@ impl FromStr for Value {
     type Err = crate::easy::de::Error;
     fn from_str(s: &str) -> Result<Value, Self::Err> {
         crate::easy::from_str(s)
+    }
+}
+
+impl serde::Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Value::Integer(value) => value.serialize(serializer),
+            Value::Float(value) => value.serialize(serializer),
+            Value::Boolean(value) => value.serialize(serializer),
+            Value::Datetime(value) => value.serialize(serializer),
+            Value::String(value) => value.serialize(serializer),
+            Value::Array(value) => value.serialize(serializer),
+            Value::Table(value) => value.serialize(serializer),
+        }
     }
 }
 


### PR DESCRIPTION
I think this is an unreasonably heavy dependency for this one trivial impl, especially in a module that already contains a 147-line bespoke Deserialize impl.