### PR TITLE
display feature guarded items on docs.rs

### DIFF
--- a/crates/serde_spanned/Cargo.toml
+++ b/crates/serde_spanned/Cargo.toml
@@ -34,5 +34,9 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/toml-rs/toml/compare/{{tag_name}}...HEAD", exactly=1},
 ]
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
+
 [dependencies]
 serde = { version = "1.0.145", optional = true }

--- a/crates/serde_spanned/src/lib.rs
+++ b/crates/serde_spanned/src/lib.rs
@@ -12,6 +12,7 @@
 // and lets them ensure that there is indeed no unsafe code as opposed to
 // something they couldn't detect (e.g. unsafe added via macro expansion, etc).
 #![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod spanned;
 pub use crate::spanned::Spanned;

--- a/crates/toml/Cargo.toml
+++ b/crates/toml/Cargo.toml
@@ -35,6 +35,9 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/toml-rs/toml/compare/{{tag_name}}...HEAD", exactly=1},
 ]
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["parse", "display"]
 parse = ["dep:toml_edit"]

--- a/crates/toml/src/lib.rs
+++ b/crates/toml/src/lib.rs
@@ -147,6 +147,7 @@
 // and lets them ensure that there is indeed no unsafe code as opposed to
 // something they couldn't detect (e.g. unsafe added via macro expansion, etc).
 #![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod map;
 pub mod value;

--- a/crates/toml_datetime/Cargo.toml
+++ b/crates/toml_datetime/Cargo.toml
@@ -31,5 +31,9 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/toml-rs/toml/compare/{{tag_name}}...HEAD", exactly=1},
 ]
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
+
 [dependencies]
 serde = { version = "1.0.145", optional = true }

--- a/crates/toml_datetime/src/lib.rs
+++ b/crates/toml_datetime/src/lib.rs
@@ -9,6 +9,7 @@
 // and lets them ensure that there is indeed no unsafe code as opposed to
 // something they couldn't detect (e.g. unsafe added via macro expansion, etc).
 #![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod datetime;
 

--- a/crates/toml_edit/Cargo.toml
+++ b/crates/toml_edit/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 ]
 
 [package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
 features = ["serde"]
 
 [package.metadata.release]

--- a/crates/toml_edit/src/lib.rs
+++ b/crates/toml_edit/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 // https://github.com/Marwes/combine/issues/172
 #![recursion_limit = "256"]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! # `toml_edit`
 //!


### PR DESCRIPTION
E.g., currently, the serde impls for `Spanned` are not shown at all on docs.rs.

Added visibility for all publicly visible items with feature guarded blocks in `serde-spanned` and `toml-datetime`. Will do the other crates if this is accepted.