### PR TITLE
feat: support deserializing types that borrow data in `from_str`

### DIFF
--- a/crates/toml/src/de.rs
+++ b/crates/toml/src/de.rs
@@ -38,9 +38,9 @@
 /// assert_eq!(config.owner.name, "Lisa");
 /// ```
 #[cfg(feature = "parse")]
-pub fn from_str<T>(s: &'_ str) -> Result<T, Error>
+pub fn from_str<'a, T>(s: &'a str) -> Result<T, Error>
 where
-    T: serde::de::DeserializeOwned,
+    T: serde::de::Deserialize<'a>,
 {
     T::deserialize(Deserializer::new(s))
 }

--- a/crates/toml/tests/testsuite/enum_external_deserialize.rs
+++ b/crates/toml/tests/testsuite/enum_external_deserialize.rs
@@ -23,9 +23,9 @@ struct Multi {
     enums: Vec<TheEnum>,
 }
 
-fn value_from_str<T>(s: &'_ str) -> Result<T, toml::de::Error>
+fn value_from_str<'a, T>(s: &'a str) -> Result<T, toml::de::Error>
 where
-    T: serde::de::DeserializeOwned,
+    T: serde::de::Deserialize<'a>,
 {
     T::deserialize(toml::de::ValueDeserializer::new(s))
 }

--- a/crates/toml/tests/testsuite/serde.rs
+++ b/crates/toml/tests/testsuite/serde.rs
@@ -1064,6 +1064,7 @@ fn datetime_offset_issue_496() {
 fn borrowed_data() {
     #[derive(Serialize, Deserialize)]
     struct Foo<'a> {
+        #[serde(borrow)]
         a: Cow<'a, str>,
     }
 

--- a/crates/toml/tests/testsuite/serde.rs
+++ b/crates/toml/tests/testsuite/serde.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -1057,4 +1058,16 @@ fn datetime_offset_issue_496() {
     let toml = original.parse::<toml::Table>().unwrap();
     let output = toml.to_string();
     snapbox::assert_eq(original, output);
+}
+
+#[test]
+fn borrowed_data() {
+    #[derive(Serialize, Deserialize)]
+    struct Foo<'a> {
+        a: Cow<'a, str>
+    }
+
+    let toml = map! { a: Value::String(String::from("bar")) };
+    assert!(toml.clone().try_into::<Foo>().is_ok());
+    assert!(toml::from_str::<Foo>(&toml.to_string()).is_ok());
 }

--- a/crates/toml/tests/testsuite/serde.rs
+++ b/crates/toml/tests/testsuite/serde.rs
@@ -1,7 +1,7 @@
-use std::borrow::Cow;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use toml::map::Map;
@@ -1064,7 +1064,7 @@ fn datetime_offset_issue_496() {
 fn borrowed_data() {
     #[derive(Serialize, Deserialize)]
     struct Foo<'a> {
-        a: Cow<'a, str>
+        a: Cow<'a, str>,
     }
 
     let toml = map! { a: Value::String(String::from("bar")) };

--- a/crates/toml/tests/testsuite/spanned.rs
+++ b/crates/toml/tests/testsuite/spanned.rs
@@ -37,9 +37,9 @@ fn test_spanned_field() {
         foo: T,
     }
 
-    fn good<T>(s: &str, expected: &str, end: Option<usize>)
+    fn good<'a, T>(s: &'a str, expected: &str, end: Option<usize>)
     where
-        T: serde::de::DeserializeOwned + Debug + PartialEq,
+        T: serde::de::Deserialize<'a> + Debug + PartialEq,
     {
         let foo: Foo<T> = toml::from_str(s).unwrap();
 

--- a/crates/toml_edit/src/de/mod.rs
+++ b/crates/toml_edit/src/de/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains all the Serde support for deserializing TOML documents into Rust structures.
 
 use serde::de::DeserializeOwned;
+use serde::Deserialize;
 
 mod array;
 mod datetime;
@@ -87,18 +88,18 @@ impl From<Error> for crate::TomlError {
 impl std::error::Error for Error {}
 
 /// Convert a value into `T`.
-pub fn from_str<T>(s: &'_ str) -> Result<T, Error>
+pub fn from_str<'a, T>(s: &'a str) -> Result<T, Error>
 where
-    T: DeserializeOwned,
+    T: Deserialize<'a>,
 {
     let de = s.parse::<Deserializer>()?;
     T::deserialize(de)
 }
 
 /// Convert a value into `T`.
-pub fn from_slice<T>(s: &'_ [u8]) -> Result<T, Error>
+pub fn from_slice<'a, T>(s: &'a [u8]) -> Result<T, Error>
 where
-    T: DeserializeOwned,
+    T: Deserialize<'a>,
 {
     let s = std::str::from_utf8(s).map_err(|e| Error::custom(e, None))?;
     from_str(s)


### PR DESCRIPTION
Some structs users may define, such as the following one, [do not implement serde's `DeserializeOwned` trait because they might borrow data from the deserializer](https://serde.rs/lifetimes.html), and thus they can't be deserialized for any lifetime:

```rust
#[derive(Deserialize)]
struct Message<'a> {
    #[serde(borrow)]
    title: Cow<'a, str>,
    #[serde(borrow)]
    text: Cow<'a, str>
}
```

Even though, as far as I know, the TOML deserializer implemented in these crates doesn't take advantage of zero-copy deserialization features, the fact that the convenience `from_str` function has a `DeserializeOwned` bound prevents it from working with such structs. [This is a regression from previous versions of the crate](https://github.com/toml-rs/toml/blob/99332f773dcf3ba3f627d842b4f9116b0b7192ff/crates/toml/src/de.rs#L73-L81).

For comparison, [`serde_json`'s equivalent function has a `Deserialize<'a>` bound instead](https://docs.rs/serde_json/1.0.91/serde_json/fn.from_str.html), where `'a` is the lifetime of the input string, that supports these structs.

Replacing `toml::from_str` with the more verbose expression `T::deserialize(toml::de::Deserializer::new(s))` works in these cases, so I think there is no compelling reason to make this function more restrictive than it needs to be.

This change should be semver-compatible according to my best interpretation of the [API evolution RFC](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md).