### PR TITLE
fix(edit): Force indexmap std support

### DIFF
--- a/crates/toml_edit/Cargo.toml
+++ b/crates/toml_edit/Cargo.toml
@@ -47,7 +47,7 @@ serde = ["dep:serde", "toml_datetime/serde", "dep:serde_spanned"]
 unbounded = []
 
 [dependencies]
-indexmap = "1.9.1"
+indexmap = { version = "1.9.1", features = ["std"] }
 winnow = "0.3.0"
 serde = { version = "1.0.145", optional = true }
 kstring = { version = "2.0.0", features = ["max_inline"], optional = true }


### PR DESCRIPTION
`indexmap` 1.9.2 and before (the latest) auto-detect the use of std.  If it fails, `IndexMap` does not default the third generic parameter, causing builds to fail.  In `indexmap` master, this is fixed by defaulting the `std` feature.

Fixes #524