### PR TITLE
serde_spanned: fix copypasta in crate description

### DIFF
--- a/crates/serde_spanned/Cargo.toml
+++ b/crates/serde_spanned/Cargo.toml
@@ -5,11 +5,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["serde", "span"]
 categories = ["encoding", "parser-implementations", "parsing", "config"]
-description = """
-A native Rust encoder and decoder of TOML-formatted files and streams. Provides
-implementations of the standard Serialize/Deserialize traits for TOML data to
-facilitate deserializing and serializing Rust structures.
-"""
+description = "Serde-compatible spanned Value"
 repository = "https://github.com/toml-rs/toml"
 homepage = "https://github.com/toml-rs/toml"
 documentation = "https://docs.rs/serde_spanned"


### PR DESCRIPTION
It looks like the crate description for the `serde_spanned` crate was copy-pasted from the `toml` crate. I've replaced it with the heading from the crate's docs instead.