### PR TITLE
Make `toml_edit::de::ValueDeserializer::new` public

### DIFF
--- a/crates/toml_edit/src/de/value.rs
+++ b/crates/toml_edit/src/de/value.rs
@@ -34,7 +34,8 @@ pub struct ValueDeserializer {
 }
 
 impl ValueDeserializer {
-    pub(crate) fn new(input: crate::Item) -> Self {
+    /// Deserialization implementation for a valid TOML item.
+    pub fn new(input: crate::Item) -> Self {
         Self {
             input,
             validate_struct_keys: false,


### PR DESCRIPTION
During updating `toml_edit` in one of the projects I've noticed that there's no `toml_edit::de::from_item` function anymore for turning `Item` into a `T: DeserializeOwned`.
Some of the values deserialized could be derived from other toml documents and field overrides, hence don't exist as a toml string to parse into `T`.

There's a `ValueDeserializer` in the new API, but it requires to get created by first parsing the TOML string:
https://github.com/toml-rs/toml/blob/5afe783acb09b7e453739c0ca6992f438b1bb6dd/crates/toml_edit/src/de/value.rs#L24-L26

and there seems to be no easy way to turn `toml_edit::Item` into `ValueDeserializer` except for the 
https://github.com/toml-rs/toml/blob/5afe783acb09b7e453739c0ca6992f438b1bb6dd/crates/toml_edit/src/de/value.rs#L37
method.

This gets even more harder for tables, since `toml_edit::Item`'s `to_string` for them generates a multiline "key = value" table string, instead of the inline table format that `ValueDeserializer` seem to require for parsing?
Also seems that internally, `ValueDeserializer::new` does not need extra conditions to be met to get created from a valid `toml_edit::Item`.

Based on all this, I'd like to have an easy way to turn a `toml_edit::Item` into `ValueDeserializer` hence the PR.