### PR TITLE
Add support for additional escape characters

### DIFF
--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -396,6 +396,7 @@ pub(crate) fn to_string_repr(
                 },
                 '\u{c}' => output.push_str("\\f"),
                 '\u{d}' => output.push_str("\\r"),
+                '\u{1b}' => output.push_str("\\e"),
                 '\u{22}' => output.push_str("\\\""),
                 '\u{5c}' => output.push_str("\\\\"),
                 c if c <= '\u{1f}' || c == '\u{7f}' => {

--- a/crates/toml_edit/tests/fixtures/invalid/string/basic-byte-escapes.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/string/basic-byte-escapes.stderr
@@ -1,6 +1,0 @@
-TOML parse error at line 1, column 13
-  |
-1 | answer = "\x33"
-  |             ^
-invalid escape sequence
-expected `b`, `f`, `n`, `r`, `t`, `u`, `U`, `\`, `"`


### PR DESCRIPTION
This patch adds support for the escapes `\xHH` and `\e` which will be part of the next TOML release.

---

I'm not sure what toml-rs' concrete policy on additions before the next official toml release is, but I found https://github.com/toml-rs/toml/issues/397 and thought contributions might be welcome.

These escapes would be extremely useful to me already, since they make specifying escape sequences like `\e[?1049h` significantly easier compared to using unicode `\u001b[?1029h`. So my goal is to make use of these upcoming TOML features even before official standardization.