### PR TITLE
fix(toml): Don't lose data when re-formatting 

### DIFF
--- a/crates/toml/src/fmt.rs
+++ b/crates/toml/src/fmt.rs
@@ -1,6 +1,7 @@
 #[derive(Copy, Clone, Default)]
 pub(crate) struct DocumentFormatter {
     pub(crate) multiline_array: bool,
+    is_value: bool,
 }
 
 impl toml_edit::visit_mut::VisitMut for DocumentFormatter {
@@ -9,21 +10,26 @@ impl toml_edit::visit_mut::VisitMut for DocumentFormatter {
     }
 
     fn visit_item_mut(&mut self, node: &mut toml_edit::Item) {
-        let other = std::mem::take(node);
-        let other = match other.into_table().map(toml_edit::Item::Table) {
-            Ok(i) => i,
-            Err(i) => i,
-        };
-        let other = match other
-            .into_array_of_tables()
-            .map(toml_edit::Item::ArrayOfTables)
-        {
-            Ok(i) => i,
-            Err(i) => i,
-        };
-        *node = other;
+        let is_parent_value = self.is_value;
+        if !is_parent_value {
+            let other = std::mem::take(node);
+            let other = match other.into_table().map(toml_edit::Item::Table) {
+                Ok(i) => i,
+                Err(i) => i,
+            };
+            let other = match other
+                .into_array_of_tables()
+                .map(toml_edit::Item::ArrayOfTables)
+            {
+                Ok(i) => i,
+                Err(i) => i,
+            };
+            self.is_value = other.is_value();
+            *node = other;
+        }
 
         toml_edit::visit_mut::visit_item_mut(self, node);
+        self.is_value = is_parent_value;
     }
 
     fn visit_table_mut(&mut self, node: &mut toml_edit::Table) {

--- a/crates/toml/tests/testsuite/serde.rs
+++ b/crates/toml/tests/testsuite/serde.rs
@@ -1202,7 +1202,7 @@ fn serialize_array_with_enum_of_optional_struct_field() {
             Choice::Optional(OptionalField { x: 3, y: Some(7) }),
         ],
     };
-    let expected = "values = [{}, \"Empty\", {}, {}]
+    let expected = "values = [{ Optional = { x = 0, y = 4 } }, \"Empty\", { Optional = { x = 2, y = 5 } }, { Optional = { x = 3, y = 7 } }]
 ";
     let raw = toml::to_string(&input).unwrap();
     snapbox::assert_eq(expected, raw);
@@ -1215,7 +1215,7 @@ fn serialize_array_with_enum_of_optional_struct_field() {
             Choice::Optional(OptionalField { x: 3, y: Some(7) }),
         ],
     };
-    let expected = "values = [{}, \"Empty\", {}, {}]
+    let expected = "values = [{ Optional = { x = 0, y = 4 } }, \"Empty\", { Optional = { x = 2 } }, { Optional = { x = 3, y = 7 } }]
 ";
     let raw = toml::to_string(&input).unwrap();
     snapbox::assert_eq(expected, raw);

--- a/crates/toml/tests/testsuite/serde.rs
+++ b/crates/toml/tests/testsuite/serde.rs
@@ -1174,3 +1174,49 @@ y = 7
     let raw = toml::to_string(&input).unwrap();
     snapbox::assert_eq(expected, raw);
 }
+
+#[test]
+fn serialize_array_with_enum_of_optional_struct_field() {
+    #[derive(Debug, Deserialize, Serialize)]
+    struct Document {
+        values: Vec<Choice>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    enum Choice {
+        Optional(OptionalField),
+        Empty,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct OptionalField {
+        x: u8,
+        y: Option<u8>,
+    }
+
+    let input = Document {
+        values: vec![
+            Choice::Optional(OptionalField { x: 0, y: Some(4) }),
+            Choice::Empty,
+            Choice::Optional(OptionalField { x: 2, y: Some(5) }),
+            Choice::Optional(OptionalField { x: 3, y: Some(7) }),
+        ],
+    };
+    let expected = "values = [{}, \"Empty\", {}, {}]
+";
+    let raw = toml::to_string(&input).unwrap();
+    snapbox::assert_eq(expected, raw);
+
+    let input = Document {
+        values: vec![
+            Choice::Optional(OptionalField { x: 0, y: Some(4) }),
+            Choice::Empty,
+            Choice::Optional(OptionalField { x: 2, y: None }),
+            Choice::Optional(OptionalField { x: 3, y: Some(7) }),
+        ],
+    };
+    let expected = "values = [{}, \"Empty\", {}, {}]
+";
+    let raw = toml::to_string(&input).unwrap();
+    snapbox::assert_eq(expected, raw);
+}

--- a/crates/toml/tests/testsuite/serde.rs
+++ b/crates/toml/tests/testsuite/serde.rs
@@ -1115,3 +1115,62 @@ fn serialize_array_with_none_value() {
     let err = toml::to_string(&input).unwrap_err();
     snapbox::assert_eq("unsupported None value", err.to_string());
 }
+
+#[test]
+fn serialize_array_with_optional_struct_field() {
+    #[derive(Debug, Deserialize, Serialize)]
+    struct Document {
+        values: Vec<OptionalField>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct OptionalField {
+        x: u8,
+        y: Option<u8>,
+    }
+
+    let input = Document {
+        values: vec![
+            OptionalField { x: 0, y: Some(4) },
+            OptionalField { x: 2, y: Some(5) },
+            OptionalField { x: 3, y: Some(7) },
+        ],
+    };
+    let expected = "\
+[[values]]
+x = 0
+y = 4
+
+[[values]]
+x = 2
+y = 5
+
+[[values]]
+x = 3
+y = 7
+";
+    let raw = toml::to_string(&input).unwrap();
+    snapbox::assert_eq(expected, raw);
+
+    let input = Document {
+        values: vec![
+            OptionalField { x: 0, y: Some(4) },
+            OptionalField { x: 2, y: None },
+            OptionalField { x: 3, y: Some(7) },
+        ],
+    };
+    let expected = "\
+[[values]]
+x = 0
+y = 4
+
+[[values]]
+x = 2
+
+[[values]]
+x = 3
+y = 7
+";
+    let raw = toml::to_string(&input).unwrap();
+    snapbox::assert_eq(expected, raw);
+}


### PR DESCRIPTION
The default formatter for `toml` was doing hijinks to the underlying
data, putting top-level items under values and these were just getting
dropped because `toml_edit` doesn't know what to do with them.

Fixes #605