### PR TITLE
fix(datetime): Verify leap years

### DIFF
--- a/crates/toml/tests/decoder_compliance.rs
+++ b/crates/toml/tests/decoder_compliance.rs
@@ -5,16 +5,7 @@ fn main() {
     let decoder = decoder::Decoder;
     let mut harness = toml_test_harness::DecoderHarness::new(decoder);
     harness.version("1.0.0");
-    harness
-        .ignore([
-            "invalid/datetime/feb-30.toml",
-            "invalid/datetime/feb-29.toml",
-            "invalid/local-date/feb-30.toml",
-            "invalid/local-date/feb-29.toml",
-            "invalid/local-datetime/feb-29.toml",
-            "invalid/local-datetime/feb-30.toml",
-        ])
-        .unwrap();
+    harness.ignore([]).unwrap();
     harness.test();
 }
 

--- a/crates/toml_datetime/src/datetime.rs
+++ b/crates/toml_datetime/src/datetime.rs
@@ -381,7 +381,8 @@ impl FromStr for Datetime {
             if time.minute > 59 {
                 return Err(DatetimeParseError {});
             }
-            if time.second > 59 {
+            // 00-58, 00-59, 00-60 based on leap second rules
+            if time.second > 60 {
                 return Err(DatetimeParseError {});
             }
             if time.nanosecond > 999_999_999 {

--- a/crates/toml_datetime/src/datetime.rs
+++ b/crates/toml_datetime/src/datetime.rs
@@ -308,7 +308,15 @@ impl FromStr for Datetime {
             if date.month < 1 || date.month > 12 {
                 return Err(DatetimeParseError {});
             }
-            if date.day < 1 || date.day > 31 {
+            let is_leap_year =
+                (date.year % 4 == 0) && ((date.year % 100 != 0) || (date.year % 400 == 0));
+            let max_days_in_month = match date.month {
+                2 if is_leap_year => 29,
+                2 => 28,
+                4 | 6 | 9 | 11 => 30,
+                _ => 31,
+            };
+            if date.day < 1 || date.day > max_days_in_month {
                 return Err(DatetimeParseError {});
             }
 

--- a/crates/toml_edit/tests/decoder_compliance.rs
+++ b/crates/toml_edit/tests/decoder_compliance.rs
@@ -4,15 +4,6 @@ fn main() {
     let decoder = decoder::Decoder;
     let mut harness = toml_test_harness::DecoderHarness::new(decoder);
     harness.version("1.0.0");
-    harness
-        .ignore([
-            "invalid/datetime/feb-30.toml",
-            "invalid/datetime/feb-29.toml",
-            "invalid/local-date/feb-30.toml",
-            "invalid/local-date/feb-29.toml",
-            "invalid/local-datetime/feb-29.toml",
-            "invalid/local-datetime/feb-30.toml",
-        ])
-        .unwrap();
+    harness.ignore([]).unwrap();
     harness.test();
 }

--- a/crates/toml_edit/tests/fixtures/invalid/datetime/feb-29.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/datetime/feb-29.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 29
+  |
+1 | "not a leap year" = 2100-02-29T15:15:15Z
+  |                             ^
+invalid date-time
+value is out of range

--- a/crates/toml_edit/tests/fixtures/invalid/datetime/feb-30.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/datetime/feb-30.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 44
+  |
+1 | "only 28 or 29 days in february" = 1988-02-30T15:15:15Z
+  |                                            ^
+invalid date-time
+value is out of range

--- a/crates/toml_edit/tests/fixtures/invalid/local-date/feb-29.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/local-date/feb-29.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 29
+  |
+1 | "not a leap year" = 2100-02-29
+  |                             ^
+invalid date-time
+value is out of range

--- a/crates/toml_edit/tests/fixtures/invalid/local-date/feb-30.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/local-date/feb-30.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 44
+  |
+1 | "only 28 or 29 days in february" = 1988-02-30
+  |                                            ^
+invalid date-time
+value is out of range

--- a/crates/toml_edit/tests/fixtures/invalid/local-datetime/feb-29.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/local-datetime/feb-29.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 29
+  |
+1 | "not a leap year" = 2100-02-29T15:15:15
+  |                             ^
+invalid date-time
+value is out of range

--- a/crates/toml_edit/tests/fixtures/invalid/local-datetime/feb-30.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/local-datetime/feb-30.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 44
+  |
+1 | "only 28 or 29 days in february" = 1988-02-30T15:15:15
+  |                                            ^
+invalid date-time
+value is out of range

--- a/deny.toml
+++ b/deny.toml
@@ -133,7 +133,7 @@ unknown-git = "deny"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = ["https://github.com/rust-fuzz/libfuzzer-sys"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for


### PR DESCRIPTION
This also makes `toml_edit` and `toml_datetime` consistent in accepting leap-seconds

Fixes #188