### PR TITLE
RFC: Always serialize NaN without sign

### DIFF
--- a/crates/toml/tests/testsuite/float.rs
+++ b/crates/toml/tests/testsuite/float.rs
@@ -47,7 +47,7 @@ macro_rules! float_inf_tests {
         assert!(inf.sf5.is_nan());
         assert!(inf.sf5.is_sign_positive());
         assert!(inf.sf6.is_nan());
-        assert!(inf.sf6.is_sign_negative());
+        assert!(inf.sf6.is_sign_negative()); // NOTE: but serializes to just `nan`
 
         assert_eq!(inf.sf7, 0.0);
         assert!(inf.sf7.is_sign_positive());
@@ -63,7 +63,7 @@ sf2 = inf
 sf3 = -inf
 sf4 = nan
 sf5 = nan
-sf6 = -nan
+sf6 = nan
 sf7 = 0.0
 sf8 = -0.0
 "

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -537,8 +537,7 @@ impl ValueRepr for f64 {
 
 fn to_f64_repr(f: f64) -> Repr {
     let repr = match (f.is_sign_negative(), f.is_nan(), f == 0.0) {
-        (true, true, _) => "-nan".to_owned(),
-        (false, true, _) => "nan".to_owned(),
+        (_, true, _) => "nan".to_owned(),
         (true, false, true) => "-0.0".to_owned(),
         (false, false, true) => "0.0".to_owned(),
         (_, false, false) => {


### PR DESCRIPTION
In all likelihood, the sign of NaNs is not meaningful in the user's program. https://github.com/rust-lang/rfcs/pull/3514#issuecomment-1781873993: _"by and large nobody cares about the sign of a NaN"_. It would usually just be surprising and undesirable for `-nan` to appear in output serialized by this crate, when the sign of the NaN was not intentionally controlled by the caller, or may even be nondeterministic if it comes from arithmetic operations or a cast.

In https://github.com/toml-lang/toml/pull/506#discussion_r153486027 it sounds like the motivation for TOML supporting `-nan` was a Robustness Principle "be liberal in what you accept from others" without the intention that TOML emitters would ever produce it.

This crate will continue to **deserialize** `-nan` as a negative NaN as implemented by https://github.com/toml-rs/toml/pull/637.