### PR TITLE
feat: Add Array::sort_by

### DIFF
--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -853,3 +853,10 @@ src.git = "https://github.com/nixos/nixpkgs"
 "#,
         );
 }
+
+#[test]
+fn sorting_with_references() {
+    let values = vec!["foo", "qux", "bar"];
+    let mut array = toml_edit::Array::from_iter(values);
+    array.sort_by(|lhs, rhs| lhs.as_str().cmp(&rhs.as_str()));
+}


### PR DESCRIPTION
`Array::sort_by_key` can't really use a borrowed key because it will be shuffling things around.  As an alternative, we can just provide the `cmp` to use.

Fixes #639