### PR TITLE
Allow from_str to take Deserialize instead of DeserializeOwned

### DIFF
--- a/crates/toml/src/de.rs
+++ b/crates/toml/src/de.rs
@@ -38,9 +38,9 @@
 /// assert_eq!(config.owner.name, "Lisa");
 /// ```
 #[cfg(feature = "parse")]
-pub fn from_str<T>(s: &'_ str) -> Result<T, Error>
+pub fn from_str<'a, T>(s: &'a str) -> Result<T, Error>
 where
-    T: serde::de::DeserializeOwned,
+    T: serde::de::Deserialize<'a>,
 {
     T::deserialize(Deserializer::new(s))
 }


### PR DESCRIPTION
This change is introduced from here: https://github.com/toml-rs/toml/pull/457/files#diff-9dfce2824f02ba265b01f477a8d9821c7509063a170db31f465e3b176bbdab3dR40

Because DeserializeOwned allows fewer types than Deserialize, it introduces regression.
By looking [serde documentation](https://serde.rs/lifetimes.html#trait-bounds), `Deserialize` looking fits more for this function
