### PR TITLE
Add Send + Sync for TableLike apis

### DIFF
--- a/crates/toml_edit/src/item.rs
+++ b/crates/toml_edit/src/item.rs
@@ -171,10 +171,11 @@ impl Item {
             Ok(i) => i,
             Err(i) => i,
         };
-        let other = match other.into_array_of_tables().map(crate::Item::ArrayOfTables) {
-            Ok(i) => i,
-            Err(i) => i,
-        };
+        let other =
+            match other.into_array_of_tables().map(crate::Item::ArrayOfTables) {
+                Ok(i) => i,
+                Err(i) => i,
+            };
         *self = other;
     }
     /// Returns true iff `self` is a value.
@@ -277,17 +278,20 @@ impl Item {
     }
 
     /// Casts `self` to either a table or an inline table.
-    pub fn as_table_like(&self) -> Option<&dyn TableLike> {
+    pub fn as_table_like(&self) -> Option<&(dyn TableLike + Send + Sync)> {
         self.as_table()
-            .map(|t| t as &dyn TableLike)
-            .or_else(|| self.as_inline_table().map(|t| t as &dyn TableLike))
+            .map(|t| t as &(dyn TableLike + Send + Sync))
+            .or_else(|| {
+                self.as_inline_table()
+                    .map(|t| t as &(dyn TableLike + Send + Sync))
+            })
     }
 
     /// Casts `self` to either a table or an inline table.
-    pub fn as_table_like_mut(&mut self) -> Option<&mut dyn TableLike> {
+    pub fn as_table_like_mut(&mut self) -> Option<&mut (dyn TableLike + Send + Sync)> {
         match self {
-            Item::Table(t) => Some(t as &mut dyn TableLike),
-            Item::Value(Value::InlineTable(t)) => Some(t as &mut dyn TableLike),
+            Item::Table(t) => Some(t as &mut (dyn TableLike + Send + Sync)),
+            Item::Value(Value::InlineTable(t)) => Some(t as &mut (dyn TableLike + Send + Sync)),
             _ => None,
         }
     }

--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -505,11 +505,11 @@ impl TableKeyValue {
 }
 
 /// An owned iterator type over `Table`'s key/value pairs.
-pub type IntoIter = Box<dyn Iterator<Item = (InternalString, Item)>>;
+pub type IntoIter = Box<dyn Iterator<Item = (InternalString, Item)> + Send + Sync>;
 /// An iterator type over `Table`'s key/value pairs.
-pub type Iter<'a> = Box<dyn Iterator<Item = (&'a str, &'a Item)> + 'a>;
+pub type Iter<'a> = Box<dyn Iterator<Item = (&'a str, &'a Item)> + Send + Sync + 'a>;
 /// A mutable iterator type over `Table`'s key/value pairs.
-pub type IterMut<'a> = Box<dyn Iterator<Item = (KeyMut<'a>, &'a mut Item)> + 'a>;
+pub type IterMut<'a> = Box<dyn Iterator<Item = (KeyMut<'a>, &'a mut Item)> + Send + Sync + 'a>;
 
 /// This trait represents either a `Table`, or an `InlineTable`.
 pub trait TableLike: crate::private::Sealed {

--- a/crates/toml_edit/src/visit.rs
+++ b/crates/toml_edit/src/visit.rs
@@ -98,7 +98,7 @@ pub trait Visit<'doc> {
         visit_inline_table(self, node)
     }
 
-    fn visit_table_like(&mut self, node: &'doc dyn TableLike) {
+    fn visit_table_like(&mut self, node: &'doc (dyn TableLike + Send + Sync)) {
         visit_table_like(self, node);
     }
 
@@ -172,7 +172,7 @@ where
     v.visit_table_like(node)
 }
 
-pub fn visit_table_like<'doc, V>(v: &mut V, node: &'doc dyn TableLike)
+pub fn visit_table_like<'doc, V>(v: &mut V, node: &'doc (dyn TableLike + Send + Sync))
 where
     V: Visit<'doc> + ?Sized,
 {

--- a/crates/toml_edit/src/visit_mut.rs
+++ b/crates/toml_edit/src/visit_mut.rs
@@ -116,7 +116,7 @@ pub trait VisitMut {
 
     /// [`visit_table_mut`](Self::visit_table_mut) and
     /// [`visit_inline_table_mut`](Self::visit_inline_table_mut) both recurse into this method.
-    fn visit_table_like_mut(&mut self, node: &mut dyn TableLike) {
+    fn visit_table_like_mut(&mut self, node: &mut (dyn TableLike + Send + Sync)) {
         visit_table_like_mut(self, node);
     }
 
@@ -190,7 +190,7 @@ where
     v.visit_table_like_mut(node);
 }
 
-pub fn visit_table_like_mut<V>(v: &mut V, node: &mut dyn TableLike)
+pub fn visit_table_like_mut<V>(v: &mut V, node: &mut (dyn TableLike + Send + Sync))
 where
     V: VisitMut + ?Sized,
 {


### PR DESCRIPTION
The current `TableLike` apis uses `dyn TableLike` without `Send` or `Sync`, while there is unlikely to be anything that blocks them from being `Send` or `Sync`.

To extend the usage of these features, I added `Send + Sync` on these apis.