### PR TITLE
fix(parser): Don't stackoverflow on opt-level=0 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,3 @@ include = [
 
 [profile.release]
 debug = 1
-
-[profile.dev]
-opt-level = 1

--- a/crates/toml_edit/src/parser/mod.rs
+++ b/crates/toml_edit/src/parser/mod.rs
@@ -99,7 +99,7 @@ pub(crate) mod prelude {
     }
 
     #[cfg(not(feature = "unbounded"))]
-    const LIMIT: usize = 128;
+    const LIMIT: usize = 100;
 
     #[cfg(not(feature = "unbounded"))]
     impl RecursionCheck {

--- a/crates/toml_edit/src/parser/mod.rs
+++ b/crates/toml_edit/src/parser/mod.rs
@@ -99,9 +99,12 @@ pub(crate) mod prelude {
     }
 
     #[cfg(not(feature = "unbounded"))]
+    const LIMIT: usize = 128;
+
+    #[cfg(not(feature = "unbounded"))]
     impl RecursionCheck {
         pub(crate) fn check_depth(depth: usize) -> Result<(), super::error::CustomError> {
-            if depth < 128 {
+            if depth < LIMIT {
                 Ok(())
             } else {
                 Err(super::error::CustomError::RecursionLimitExceeded)
@@ -113,7 +116,7 @@ pub(crate) mod prelude {
             input: &mut Input<'_>,
         ) -> Result<Self, winnow::error::ErrMode<ContextError>> {
             self.current += 1;
-            if self.current < 128 {
+            if self.current < LIMIT {
                 Ok(self)
             } else {
                 Err(winnow::error::ErrMode::from_external_error(


### PR DESCRIPTION
Overriding the `opt-level` dates back to the initial creation of `toml_edit` without any justification given so likely fine to remove.

Fixes #702