### PR TITLE
fix(parser): Return correct span for multi-byte characters 

### DIFF
--- a/crates/toml_edit/src/error.rs
+++ b/crates/toml_edit/src/error.rs
@@ -21,19 +21,23 @@ impl TomlError {
     ) -> Self {
         use winnow::stream::Stream;
 
-        let offset = error.offset();
-        let span = if offset == raw.len() {
-            offset..offset
-        } else {
-            offset..(offset + 1)
-        };
-
         let message = error.inner().to_string();
         let raw = raw.finish();
+        let raw = String::from_utf8(raw.to_owned()).expect("original document was utf8");
+
+        let offset = error.offset();
+        let mut indices = raw[offset..].char_indices();
+        indices.next();
+        let len = if let Some((index, _)) = indices.next() {
+            index
+        } else {
+            raw.len()
+        };
+        let span = offset..(offset + len);
 
         Self {
             message,
-            raw: Some(String::from_utf8(raw.to_owned()).expect("original document was utf8")),
+            raw: Some(raw),
             keys: Vec::new(),
             span: Some(span),
         }

--- a/crates/toml_edit/tests/fixtures/invalid/key/special-character.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/key/special-character.stderr
@@ -1,5 +1,5 @@
 TOML parse error at line 1, column 1
   |
 1 | μ = "greek small letter mu"
-  | ^
+  | ^^
 invalid key

--- a/crates/toml_edit/tests/fixtures/invalid/table/no-close-2.stderr
+++ b/crates/toml_edit/tests/fixtures/invalid/table/no-close-2.stderr
@@ -1,6 +1,6 @@
 TOML parse error at line 1, column 25
   |
 1 | [closing-bracket.missingö
-  |                         ^
+  |                         ^^
 invalid table header
 expected `.`, `]`

--- a/crates/toml_edit/tests/testsuite/invalid.rs
+++ b/crates/toml_edit/tests/testsuite/invalid.rs
@@ -209,3 +209,12 @@ dotted key `k1` attempted to extend non-table type (integer)
     let err = toml_input.parse::<toml_edit::DocumentMut>().unwrap_err();
     snapbox::assert_eq(expected_err, err.to_string());
 }
+
+#[test]
+#[should_panic]
+fn emoji_error_span() {
+    let input = "😀";
+    let err = input.parse::<toml_edit::DocumentMut>().unwrap_err();
+    dbg!(err.span());
+    let _ = &input[err.span().unwrap()];
+}

--- a/crates/toml_edit/tests/testsuite/invalid.rs
+++ b/crates/toml_edit/tests/testsuite/invalid.rs
@@ -211,10 +211,10 @@ dotted key `k1` attempted to extend non-table type (integer)
 }
 
 #[test]
-#[should_panic]
 fn emoji_error_span() {
     let input = "😀";
     let err = input.parse::<toml_edit::DocumentMut>().unwrap_err();
     dbg!(err.span());
-    let _ = &input[err.span().unwrap()];
+    let actual = &input[err.span().unwrap()];
+    assert_eq!(actual, input);
 }


### PR DESCRIPTION
This is a step towards addressing rust-lang/cargo#13772