### PR TITLE
fix(parser): Ensure error spans are valid for escape sequences

### DIFF
--- a/crates/toml_edit/src/error.rs
+++ b/crates/toml_edit/src/error.rs
@@ -26,6 +26,11 @@ impl TomlError {
         let raw = String::from_utf8(raw.to_owned()).expect("original document was utf8");
 
         let offset = error.offset();
+        let offset = (0..=offset)
+            .rev()
+            .find(|index| raw.is_char_boundary(*index))
+            .unwrap_or(0);
+
         let mut indices = raw[offset..].char_indices();
         indices.next();
         let len = if let Some((index, _)) = indices.next() {

--- a/crates/toml_edit/tests/testsuite/invalid.rs
+++ b/crates/toml_edit/tests/testsuite/invalid.rs
@@ -227,3 +227,12 @@ fn text_error_span() {
     let actual = &input[err.span().unwrap()];
     assert_eq!(actual, "");
 }
+
+#[test]
+fn fuzzed_68144_error_span() {
+    let input = "\"\\ᾂr\"";
+    let err = input.parse::<toml_edit::DocumentMut>().unwrap_err();
+    dbg!(err.span());
+    let actual = &input[err.span().unwrap()];
+    assert_eq!(actual, "ᾂ");
+}


### PR DESCRIPTION
After a `\` in a string, the parser consumes the next character and then validates it.
If the validation fails, it means that the parser is now pointing to the next byte after it which could be within a byte sequence.

We likely want to fix up some of these cases so errors point to the right thing but in the mean time, we should make sure this doesn't produce a bad span.