### PR TITLE
Add some safety docs

### DIFF
--- a/crates/toml_edit/src/parser/datetime.rs
+++ b/crates/toml_edit/src/parser/datetime.rs
@@ -255,6 +255,7 @@ pub(crate) fn unsigned_digits<'i, const MIN: usize, const MAX: usize>(
     input: &mut Input<'i>,
 ) -> PResult<&'i str> {
     take_while(MIN..=MAX, DIGIT)
+        // Safety: `digit` only produces ASCII
         .map(|b: &[u8]| unsafe { from_utf8_unchecked(b, "`is_ascii_digit` filters out on-ASCII") })
         .parse_next(input)
 }

--- a/crates/toml_edit/src/parser/key.rs
+++ b/crates/toml_edit/src/parser/key.rs
@@ -90,6 +90,7 @@ pub(crate) fn simple_key(input: &mut Input<'_>) -> PResult<(RawString, InternalS
 fn unquoted_key<'i>(input: &mut Input<'i>) -> PResult<&'i str> {
     trace(
         "unquoted-key",
+        // Safety: UNQUOTED_CHAR is only ASCII ranges
         take_while(1.., UNQUOTED_CHAR)
             .map(|b| unsafe { from_utf8_unchecked(b, "`is_unquoted_char` filters out on-ASCII") }),
     )
@@ -101,6 +102,7 @@ pub(crate) fn is_unquoted_char(c: u8) -> bool {
     UNQUOTED_CHAR.contains_token(c)
 }
 
+// Safety-usable invariant: UNQUOTED_CHAR is only ASCII ranges
 const UNQUOTED_CHAR: (
     RangeInclusive<u8>,
     RangeInclusive<u8>,

--- a/crates/toml_edit/src/parser/strings.rs
+++ b/crates/toml_edit/src/parser/strings.rs
@@ -218,7 +218,8 @@ fn mlb_quotes<'i>(
     move |input: &mut Input<'i>| {
         let start = input.checkpoint();
         let res = terminated(b"\"\"", peek(term.by_ref()))
-            // Safety: ???
+            // Safety: terminated returns the output of the first parser here,
+            // which only parses ASCII
             .map(|b| unsafe { from_utf8_unchecked(b, "`bytes` out non-ASCII") })
             .parse_next(input);
 
@@ -226,7 +227,8 @@ fn mlb_quotes<'i>(
             Err(winnow::error::ErrMode::Backtrack(_)) => {
                 input.reset(&start);
                 terminated(b"\"", peek(term.by_ref()))
-                    // Safety: ???
+                    // Safety: terminated returns the output of the first parser here,
+                    // which only parses ASCII
                     .map(|b| unsafe { from_utf8_unchecked(b, "`bytes` out non-ASCII") })
                     .parse_next(input)
             }
@@ -349,7 +351,8 @@ fn mll_quotes<'i>(
     move |input: &mut Input<'i>| {
         let start = input.checkpoint();
         let res = terminated(b"''", peek(term.by_ref()))
-            // Safety: ???
+            // Safety: terminated returns the output of the first parser here,
+            // which only parses ASCII
             .map(|b| unsafe { from_utf8_unchecked(b, "`bytes` out non-ASCII") })
             .parse_next(input);
 
@@ -357,7 +360,8 @@ fn mll_quotes<'i>(
             Err(winnow::error::ErrMode::Backtrack(_)) => {
                 input.reset(&start);
                 terminated(b"'", peek(term.by_ref()))
-                    // Safety: ???
+                    // Safety: terminated returns the output of the first parser here,
+                    // which only parses ASCII
                     .map(|b| unsafe { from_utf8_unchecked(b, "`bytes` out non-ASCII") })
                     .parse_next(input)
             }

--- a/crates/toml_edit/src/parser/strings.rs
+++ b/crates/toml_edit/src/parser/strings.rs
@@ -138,6 +138,7 @@ fn escape_seq_char(input: &mut Input<'_>) -> PResult<char> {
 pub(crate) fn hexescape<const N: usize>(input: &mut Input<'_>) -> PResult<char> {
     take_while(0..=N, HEXDIG)
         .verify(|b: &[u8]| b.len() == N)
+        // Safety: HEXDIG is ASCII-only
         .map(|b: &[u8]| unsafe { from_utf8_unchecked(b, "`is_ascii_digit` filters out on-ASCII") })
         .verify_map(|s| u32::from_str_radix(s, 16).ok())
         .try_map(|h| char::from_u32(h).ok_or(CustomError::OutOfRange))
@@ -217,6 +218,7 @@ fn mlb_quotes<'i>(
     move |input: &mut Input<'i>| {
         let start = input.checkpoint();
         let res = terminated(b"\"\"", peek(term.by_ref()))
+            // Safety: ???
             .map(|b| unsafe { from_utf8_unchecked(b, "`bytes` out non-ASCII") })
             .parse_next(input);
 
@@ -224,6 +226,7 @@ fn mlb_quotes<'i>(
             Err(winnow::error::ErrMode::Backtrack(_)) => {
                 input.reset(&start);
                 terminated(b"\"", peek(term.by_ref()))
+                    // Safety: ???
                     .map(|b| unsafe { from_utf8_unchecked(b, "`bytes` out non-ASCII") })
                     .parse_next(input)
             }
@@ -346,6 +349,7 @@ fn mll_quotes<'i>(
     move |input: &mut Input<'i>| {
         let start = input.checkpoint();
         let res = terminated(b"''", peek(term.by_ref()))
+            // Safety: ???
             .map(|b| unsafe { from_utf8_unchecked(b, "`bytes` out non-ASCII") })
             .parse_next(input);
 
@@ -353,6 +357,7 @@ fn mll_quotes<'i>(
             Err(winnow::error::ErrMode::Backtrack(_)) => {
                 input.reset(&start);
                 terminated(b"'", peek(term.by_ref()))
+                    // Safety: ???
                     .map(|b| unsafe { from_utf8_unchecked(b, "`bytes` out non-ASCII") })
                     .parse_next(input)
             }


### PR DESCRIPTION
I was performing a safety review of this crate and found the existing string comments a bit hard to follow. In particular, a lot of them refer to functions outside of the module for their invariants, which feels sketchy, until you realize that most of them are relying on relatively local invariants based on constants.

I added explicit safety comments for all of the unsafe in toml_edit. However I'm unable to figure out why `mlb_quotes` and `mll_quotes` are safe. There is no call to `bytes` there, and it seems to be using a `terminated` parser.