### PR TITLE
docs: Remove confusing example version

### DIFF
--- a/crates/toml/src/lib.rs
+++ b/crates/toml/src/lib.rs
@@ -5,7 +5,6 @@
 //! ```toml
 //! [package]
 //! name = "toml"
-//! version = "0.4.2"
 //! authors = ["Alex Crichton <alex@alexcrichton.com>"]
 //!
 //! [dependencies]


### PR DESCRIPTION
The version in the TOML example in the main documentation on docs.rs can be easily confused with the latest version of the crate, which is multiple versions newer.