### PR TITLE
fix(encode): Prefer literals over escaping double-quotes 

### DIFF
--- a/crates/toml/tests/testsuite/display.rs
+++ b/crates/toml/tests/testsuite/display.rs
@@ -75,7 +75,7 @@ fn table() {
         }
         .to_string(),
         "\"foo.bar\" = 2\n\
-         \"foo\\\"bar\" = 2\n"
+         'foo\"bar' = 2\n"
     );
     assert_eq!(
         map! {

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -439,6 +439,9 @@ fn infer_style(value: &str) -> (StringStyle, bool) {
             }
             match ch {
                 '\t' => {}
+                '"' => {
+                    prefer_literal = true;
+                }
                 '\\' => {
                     prefer_literal = true;
                 }

--- a/crates/toml_edit/src/key.rs
+++ b/crates/toml_edit/src/key.rs
@@ -289,17 +289,13 @@ fn to_key_repr(key: &str) -> Repr {
             crate::encode::to_string_repr(
                 key,
                 Some(crate::encode::StringStyle::OnelineSingle),
-                Some(false),
+                None,
             )
         }
     }
     #[cfg(not(feature = "parse"))]
     {
-        crate::encode::to_string_repr(
-            key,
-            Some(crate::encode::StringStyle::OnelineSingle),
-            Some(false),
-        )
+        crate::encode::to_string_repr(key, Some(crate::encode::StringStyle::OnelineSingle), None)
     }
 }
 

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -222,9 +222,9 @@ fn test_insert_key_with_quotes() {
 
         [target]
 
-[target."cfg(target_os = \"linux\")"]
+[target.'cfg(target_os = "linux")']
 
-[target."cfg(target_os = \"linux\")".dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 name = "dep"
         
 "#]]);

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -200,6 +200,36 @@ key3 = 8.1415926
 "#]]);
 }
 
+#[test]
+fn test_insert_key_with_quotes() {
+    given(
+        r#"
+        [package]
+        name = "foo"
+
+        [target]
+        "#,
+    )
+    .running(|root| {
+        root["target"]["cfg(target_os = \"linux\")"] = table();
+        root["target"]["cfg(target_os = \"linux\")"]["dependencies"] = table();
+        root["target"]["cfg(target_os = \"linux\")"]["dependencies"]["name"] = value("dep");
+    })
+    .produces_display(str![[r#"
+
+        [package]
+        name = "foo"
+
+        [target]
+
+[target."cfg(target_os = \"linux\")"]
+
+[target."cfg(target_os = \"linux\")".dependencies]
+name = "dep"
+        
+"#]]);
+}
+
 // removal
 
 #[test]


### PR DESCRIPTION
Part of rust-lang/cargo#14002