### PR TITLE
refactor: make repr more public

### DIFF
--- a/crates/toml_edit/src/key.rs
+++ b/crates/toml_edit/src/key.rs
@@ -53,7 +53,10 @@ impl Key {
         Self::try_parse_path(repr)
     }
 
-    pub(crate) fn with_repr_unchecked(mut self, repr: Repr) -> Self {
+    /// While creating the `Key`, add `Repr` to it
+    ///
+    /// Useful in custom parsers.
+    pub fn with_repr_unchecked(mut self, repr: Repr) -> Self {
         self.repr = Some(repr);
         self
     }

--- a/crates/toml_edit/src/repr.rs
+++ b/crates/toml_edit/src/repr.rs
@@ -141,7 +141,10 @@ pub struct Repr {
 }
 
 impl Repr {
-    pub(crate) fn new_unchecked(raw: impl Into<RawString>) -> Self {
+    /// Create a new TOML-encoded value
+    ///
+    /// Useful in custom parsers.
+    pub fn new_unchecked(raw: impl Into<RawString>) -> Self {
         Repr {
             raw_value: raw.into(),
         }


### PR DESCRIPTION
We are implementing a library to access TOML data via a "TOML path" like `foo[1].bar`, similar to [toml-cli](https://github.com/gnprice/toml-cli). Reusing the key parser provided by the public interface is tricky but possible and would be desired. But for additional feature requirements (like wildcards) we cannot use existing parser, and we cannot create a key in our parser because we need to set `Repr`.

This patch makes more public relevant parts for working with `Repr` so that we can create keys within our parser.