### PR TITLE
perf(parse): Reduce overheasd from "trivia"

### DIFF
--- a/crates/benchmarks/examples/bench.rs
+++ b/crates/benchmarks/examples/bench.rs
@@ -38,10 +38,7 @@ impl Args {
         let mut parser = Parser::Document;
 
         let mut args = lexopt::Parser::from_env();
-        let mut data = toml_benchmarks::MANIFESTS
-            .iter()
-            .find(|d| d.name() == "1-medium")
-            .unwrap();
+        let mut data_name = "1-medium".to_owned();
         while let Some(arg) = args.next()? {
             match arg {
                 Long("parser") => {
@@ -59,18 +56,18 @@ impl Args {
                     };
                 }
                 Long("manifest") => {
-                    let name = args.value()?;
-                    data = toml_benchmarks::MANIFESTS
-                        .iter()
-                        .find(|d| d.name() == name)
-                        .ok_or_else(|| lexopt::Error::UnexpectedValue {
-                            option: "manifest".to_owned(),
-                            value: name.clone(),
-                        })?;
+                    data_name = args.value()?.string()?;
                 }
                 _ => return Err(arg.unexpected()),
             }
         }
+        let data = toml_benchmarks::MANIFESTS
+            .iter()
+            .find(|d| d.name() == data_name)
+            .ok_or_else(|| lexopt::Error::UnexpectedValue {
+                option: "manifest".to_owned(),
+                value: data_name.into(),
+            })?;
 
         Ok(Self {
             parser,

--- a/crates/toml_edit/src/parser/strings.rs
+++ b/crates/toml_edit/src/parser/strings.rs
@@ -328,7 +328,7 @@ fn ml_literal_body<'i>(input: &mut Input<'i>) -> PResult<&'i str> {
 
 // mll-content = mll-char / newline
 fn mll_content(input: &mut Input<'_>) -> PResult<u8> {
-    alt((one_of(MLL_CHAR), newline)).parse_next(input)
+    alt((one_of(MLL_CHAR), newline.value(b'\n'))).parse_next(input)
 }
 
 // mll-char = %x09 / %x20-26 / %x28-7E / non-ascii

--- a/crates/toml_edit/src/parser/trivia.rs
+++ b/crates/toml_edit/src/parser/trivia.rs
@@ -93,20 +93,12 @@ pub(crate) fn ws_newlines<'i>(input: &mut Input<'i>) -> PResult<&'i str> {
 // note: this rule is not present in the original grammar
 // ws-comment-newline = *( ws-newline-nonempty / comment )
 pub(crate) fn ws_comment_newline<'i>(input: &mut Input<'i>) -> PResult<&'i [u8]> {
-    repeat(
-        0..,
-        alt((
-            repeat(
-                1..,
-                alt((take_while(1.., WSCHAR), newline.value(&b"\n"[..]))),
-            )
-            .map(|()| ()),
-            comment.void(),
-        )),
+    (
+        repeat(0.., (take_while(0.., WSCHAR), opt(comment), newline)).map(|()| ()),
+        take_while(0.., WSCHAR),
     )
-    .map(|()| ())
-    .recognize()
-    .parse_next(input)
+        .recognize()
+        .parse_next(input)
 }
 
 // note: this rule is not present in the original grammar

--- a/crates/toml_edit/src/parser/trivia.rs
+++ b/crates/toml_edit/src/parser/trivia.rs
@@ -1,11 +1,14 @@
 use std::ops::RangeInclusive;
 
 use winnow::combinator::alt;
+use winnow::combinator::empty;
 use winnow::combinator::eof;
+use winnow::combinator::fail;
 use winnow::combinator::opt;
 use winnow::combinator::repeat;
 use winnow::combinator::terminated;
 use winnow::prelude::*;
+use winnow::token::any;
 use winnow::token::one_of;
 use winnow::token::take_while;
 
@@ -59,7 +62,12 @@ pub(crate) fn comment(input: &mut Input<'_>) -> PResult<()> {
 // newline = ( %x0A /              ; LF
 //             %x0D.0A )           ; CRLF
 pub(crate) fn newline(input: &mut Input<'_>) -> PResult<()> {
-    alt((one_of(LF).void(), (one_of(CR), one_of(LF)).void())).parse_next(input)
+    dispatch! {any;
+        b'\n' => empty,
+        b'\r' => one_of(LF).void(),
+        _ => fail,
+    }
+    .parse_next(input)
 }
 pub(crate) const LF: u8 = b'\n';
 pub(crate) const CR: u8 = b'\r';

--- a/crates/toml_edit/tests/testsuite/parse.rs
+++ b/crates/toml_edit/tests/testsuite/parse.rs
@@ -309,13 +309,12 @@ TOML parse error at line 1, column 1
     bad!(
         "a = [ \r ]",
         str![[r#"
-TOML parse error at line 1, column 7
+TOML parse error at line 1, column 8
   |
 1 | a = [ 
  ]
-  |       ^
-invalid array
-expected `]`
+  |        ^
+
 
 "#]]
     );


### PR DESCRIPTION
`ws_comment_newline` was showing up in callgrind when dealing with a lot of features.  While this had some impact on benchmarks, it wasn't super big.