### PR TITLE
refactor(parser): Clarify results in profiler

### DIFF
--- a/crates/toml_edit/src/parser/document.rs
+++ b/crates/toml_edit/src/parser/document.rs
@@ -109,7 +109,7 @@ pub(crate) fn parse_keyval(input: &mut Input<'_>) -> PResult<(Vec<Key>, TableKey
                     .context(StrContext::Expected(StrContextValue::CharLiteral('='))),
                 (
                     ws.span(),
-                    value(RecursionCheck::default()),
+                    value,
                     line_trailing
                         .context(StrContext::Expected(StrContextValue::CharLiteral('\n')))
                         .context(StrContext::Expected(StrContextValue::CharLiteral('#'))),

--- a/crates/toml_edit/src/parser/mod.rs
+++ b/crates/toml_edit/src/parser/mod.rs
@@ -23,7 +23,7 @@ pub(crate) fn parse_document<S: AsRef<str>>(raw: S) -> Result<crate::ImDocument<
     let state = RefCell::new(state::ParseState::new());
     let state_ref = &state;
     document::document(state_ref)
-        .parse(b)
+        .parse(b.clone())
         .map_err(|e| TomlError::new(e, b))?;
     let doc = state
         .into_inner()
@@ -36,7 +36,7 @@ pub(crate) fn parse_key(raw: &str) -> Result<crate::Key, TomlError> {
     use prelude::*;
 
     let b = new_input(raw);
-    let result = key::simple_key.parse(b);
+    let result = key::simple_key.parse(b.clone());
     match result {
         Ok((raw, key)) => {
             Ok(crate::Key::new(key).with_repr_unchecked(crate::Repr::new_unchecked(raw)))
@@ -49,7 +49,7 @@ pub(crate) fn parse_key_path(raw: &str) -> Result<Vec<crate::Key>, TomlError> {
     use prelude::*;
 
     let b = new_input(raw);
-    let result = key::key.parse(b);
+    let result = key::key.parse(b.clone());
     match result {
         Ok(mut keys) => {
             for key in &mut keys {
@@ -65,7 +65,7 @@ pub(crate) fn parse_value(raw: &str) -> Result<crate::Value, TomlError> {
     use prelude::*;
 
     let b = new_input(raw);
-    let parsed = value::value(RecursionCheck::default()).parse(b);
+    let parsed = value::value.parse(b.clone());
     match parsed {
         Ok(mut value) => {
             // Only take the repr and not decor, as its probably not intended
@@ -86,13 +86,16 @@ pub(crate) mod prelude {
     pub(crate) use winnow::PResult;
     pub(crate) use winnow::Parser;
 
-    pub(crate) type Input<'b> = winnow::Located<&'b winnow::BStr>;
+    pub(crate) type Input<'b> = winnow::Stateful<winnow::Located<&'b winnow::BStr>, RecursionCheck>;
 
     pub(crate) fn new_input(s: &str) -> Input<'_> {
-        winnow::Located::new(winnow::BStr::new(s))
+        winnow::Stateful {
+            input: winnow::Located::new(winnow::BStr::new(s)),
+            state: Default::default(),
+        }
     }
 
-    #[derive(Copy, Clone, Debug, Default)]
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
     pub(crate) struct RecursionCheck {
         #[cfg(not(feature = "unbounded"))]
         current: usize,
@@ -111,24 +114,40 @@ pub(crate) mod prelude {
             Ok(())
         }
 
-        #[allow(unused_mut)]
-        pub(crate) fn recursing(
-            mut self,
-            _input: &mut Input<'_>,
-        ) -> Result<Self, winnow::error::ErrMode<ContextError>> {
+        fn enter(&mut self) -> Result<(), super::error::CustomError> {
             #[cfg(not(feature = "unbounded"))]
             {
                 self.current += 1;
                 if LIMIT <= self.current {
-                    return Err(winnow::error::ErrMode::from_external_error(
-                        _input,
-                        winnow::error::ErrorKind::Eof,
-                        super::error::CustomError::RecursionLimitExceeded,
-                    )
-                    .cut());
+                    return Err(super::error::CustomError::RecursionLimitExceeded);
                 }
             }
-            Ok(self)
+            Ok(())
+        }
+
+        fn exit(&mut self) {
+            #[cfg(not(feature = "unbounded"))]
+            {
+                self.current -= 1;
+            }
+        }
+    }
+
+    pub(crate) fn check_recursion<'b, O>(
+        mut parser: impl Parser<Input<'b>, O, ContextError>,
+    ) -> impl Parser<Input<'b>, O, ContextError> {
+        move |input: &mut Input<'b>| {
+            input.state.enter().map_err(|err| {
+                winnow::error::ErrMode::from_external_error(
+                    input,
+                    winnow::error::ErrorKind::Eof,
+                    err,
+                )
+                .cut()
+            })?;
+            let result = parser.parse_next(input);
+            input.state.exit();
+            result
         }
     }
 }

--- a/crates/toml_edit/src/parser/value.rs
+++ b/crates/toml_edit/src/parser/value.rs
@@ -14,17 +14,16 @@ use crate::RawString;
 use crate::Value;
 
 // val = string / boolean / array / inline-table / date-time / float / integer
-pub(crate) fn value<'i>(check: RecursionCheck) -> impl Parser<Input<'i>, Value, ContextError> {
-    move |input: &mut Input<'i>| {
-        dispatch!{peek(any);
+pub(crate) fn value(input: &mut Input<'_>) -> PResult<Value> {
+    dispatch! {peek(any);
             crate::parser::strings::QUOTATION_MARK |
             crate::parser::strings::APOSTROPHE => string.map(|s| {
                 Value::String(Formatted::new(
                     s.into_owned()
                 ))
             }),
-            crate::parser::array::ARRAY_OPEN => array(check).map(Value::Array),
-            crate::parser::inline_table::INLINE_TABLE_OPEN => inline_table(check).map(Value::InlineTable),
+            crate::parser::array::ARRAY_OPEN => check_recursion(array).map(Value::Array),
+            crate::parser::inline_table::INLINE_TABLE_OPEN => check_recursion(inline_table).map(Value::InlineTable),
             // Date/number starts
             b'+' | b'-' | b'0'..=b'9' => {
                 // Uncommon enough not to be worth optimizing at this time
@@ -80,10 +79,9 @@ pub(crate) fn value<'i>(check: RecursionCheck) -> impl Parser<Input<'i>, Value, 
                     .context(StrContext::Expected(StrContextValue::CharLiteral('\'')))
             },
     }
-        .with_span()
-        .map(|(value, span)| apply_raw(value, span))
-        .parse_next(input)
-    }
+    .with_span()
+    .map(|(value, span)| apply_raw(value, span))
+    .parse_next(input)
 }
 
 fn apply_raw(mut val: Value, span: std::ops::Range<usize>) -> Value {
@@ -146,7 +144,7 @@ trimmed in raw strings.
         ];
         for input in inputs {
             dbg!(input);
-            let mut parsed = value(Default::default()).parse(new_input(input));
+            let mut parsed = value.parse(new_input(input));
             if let Ok(parsed) = &mut parsed {
                 parsed.despan(input);
             }


### PR DESCRIPTION
Be removing the extra closure, it somehow made things easier to read (despite using closures in so many other places).

This is also closer to where I want the parser to be long term.