### PR TITLE
perf(parser): Optimize array parsing

### DIFF
--- a/crates/toml_edit/src/parser/array.rs
+++ b/crates/toml_edit/src/parser/array.rs
@@ -40,15 +40,15 @@ const ARRAY_SEP: u8 = b',';
 // array-values = [ ( array-value array-sep array-values ) /
 //                  array-value / ws-comment-newline ]
 pub(crate) fn array_values(input: &mut Input<'_>) -> PResult<Array> {
-    let array = opt((separated(1.., array_value, ARRAY_SEP), opt(ARRAY_SEP))
-        .map(|(v, trailing): (Vec<Item>, Option<u8>)| (Array::with_vec(v), trailing.is_some())))
-    .parse_next(input)?;
-
+    let array = separated(0.., array_value, ARRAY_SEP).parse_next(input)?;
+    let mut array = Array::with_vec(array);
+    if !array.is_empty() {
+        let comma = opt(ARRAY_SEP).parse_next(input)?.is_some();
+        array.set_trailing_comma(comma);
+    }
     let trailing = ws_comment_newline.span().parse_next(input)?;
-
-    let (mut array, comma) = array.unwrap_or_default();
-    array.set_trailing_comma(comma);
     array.set_trailing(RawString::with_span(trailing));
+
     Ok(array)
 }
 

--- a/crates/toml_edit/src/parser/array.rs
+++ b/crates/toml_edit/src/parser/array.rs
@@ -36,9 +36,8 @@ const ARRAY_CLOSE: u8 = b']';
 // array-sep = ws %x2C ws  ; , Comma
 const ARRAY_SEP: u8 = b',';
 
-// note: this rule is modified
-// array-values = [ ( array-value array-sep array-values ) /
-//                  array-value / ws-comment-newline ]
+// array-values =  ws-comment-newline val ws-comment-newline array-sep array-values
+// array-values =/ ws-comment-newline val ws-comment-newline [ array-sep ]
 pub(crate) fn array_values(input: &mut Input<'_>) -> PResult<Array> {
     let array = separated(0.., array_value, ARRAY_SEP).parse_next(input)?;
     let mut array = Array::with_vec(array);

--- a/crates/toml_edit/src/parser/array.rs
+++ b/crates/toml_edit/src/parser/array.rs
@@ -63,9 +63,10 @@ pub(crate) fn array_values(input: &mut Input<'_>) -> PResult<Array> {
 }
 
 pub(crate) fn array_value(input: &mut Input<'_>) -> PResult<Value> {
-    (ws_comment_newline.span(), value, ws_comment_newline.span())
-        .map(|(ws1, v, ws2)| v.decorated(RawString::with_span(ws1), RawString::with_span(ws2)))
-        .parse_next(input)
+    let prefix = ws_comment_newline.span().parse_next(input)?;
+    let value = value.parse_next(input)?;
+    let suffix = ws_comment_newline.span().parse_next(input)?;
+    Ok(value.decorated(RawString::with_span(prefix), RawString::with_span(suffix)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is focused on `[features]` tables which in some corner cases, may have a large number of empty or single-item arrays.