### PR TITLE
feat: Implement source for `toml::de::Error` and `toml_edit::de::Error`

### DIFF
--- a/crates/toml/src/de.rs
+++ b/crates/toml/src/de.rs
@@ -87,7 +87,11 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.inner)
+    }
+}
 
 /// Deserialization TOML document
 ///

--- a/crates/toml_edit/src/de/mod.rs
+++ b/crates/toml_edit/src/de/mod.rs
@@ -83,7 +83,11 @@ impl From<Error> for crate::TomlError {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.inner)
+    }
+}
 
 /// Convert a TOML [documents][crate::DocumentMut] into `T`.
 #[cfg(feature = "parse")]


### PR DESCRIPTION
Both `toml::de::Error` and `toml_edit::de::Error` provide `inner`, but without implementing the `source` method of `std::error::Error` it is not possible to access it.

Fixes: https://github.com/toml-rs/toml/issues/800