### PR TITLE
fix: Preserve dotted-key ordering

### DIFF
--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -2,7 +2,7 @@ use std::iter::FromIterator;
 
 use crate::key::Key;
 use crate::repr::Decor;
-use crate::table::{Iter, IterMut, KeyValuePairs, TableLike};
+use crate::table::{Iter, IterMut, KeyValuePairs, TableLike, sort_values_by_position};
 use crate::{InternalString, Item, KeyMut, RawString, Table, Value};
 
 /// Type representing a TOML inline table,
@@ -75,6 +75,7 @@ impl InlineTable {
                 _ => {}
             }
         }
+        sort_values_by_position(values);
     }
 
     /// Auto formats the table.

--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -2,7 +2,7 @@ use std::iter::FromIterator;
 
 use crate::key::Key;
 use crate::repr::Decor;
-use crate::table::{Iter, IterMut, KeyValuePairs, TableLike, sort_values_by_position};
+use crate::table::{Iter, IterMut, KeyValuePairs, TableLike, sort_values_by_position, modify_key_position};
 use crate::{InternalString, Item, KeyMut, RawString, Table, Value};
 
 /// Type representing a TOML inline table,
@@ -87,14 +87,14 @@ impl InlineTable {
     pub fn sort_values(&mut self) {
         // Assuming standard tables have their position set and this won't negatively impact them
         self.items.sort_keys();
-        for value in self.items.values_mut() {
+        modify_key_position(&mut self.items,|value| {
             match value {
                 Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
                     table.sort_values();
                 }
                 _ => {}
             }
-        }
+        });
     }
 
     /// Sort Key/Value Pairs of the table using the using the comparison function `compare`.
@@ -123,14 +123,14 @@ impl InlineTable {
             };
 
         self.items.sort_by(modified_cmp);
-        for value in self.items.values_mut() {
+        modify_key_position(&mut self.items,|value| {
             match value {
                 Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
                     table.sort_values_by_internal(compare);
                 }
                 _ => {}
             }
-        }
+        });
     }
 
     /// If a table has no key/value pairs and implicit, it will not be displayed.

--- a/crates/toml_edit/src/key.rs
+++ b/crates/toml_edit/src/key.rs
@@ -32,6 +32,7 @@ pub struct Key {
     pub(crate) repr: Option<Repr>,
     pub(crate) leaf_decor: Decor,
     pub(crate) dotted_decor: Decor,
+    pub(crate) position: Option<usize>,
 }
 
 impl Key {
@@ -42,6 +43,7 @@ impl Key {
             repr: None,
             leaf_decor: Default::default(),
             dotted_decor: Default::default(),
+            position: Default::default(),
         }
     }
 
@@ -73,6 +75,12 @@ impl Key {
     /// While creating the `Key`, add `Decor` to it for between dots
     pub fn with_dotted_decor(mut self, decor: Decor) -> Self {
         self.dotted_decor = decor;
+        self
+    }
+
+    /// While creating the `Key`, add a table position to it
+    pub fn with_position(mut self, position: Option<usize>) -> Self {
+        self.position = position;
         self
     }
 
@@ -158,6 +166,16 @@ impl Key {
         }
     }
 
+    /// Get the position relative to other keys in parent table
+    pub fn position(&self) -> Option<usize> {
+        return self.position;
+    }
+
+    /// Set the position relative to other keys in parent table
+    pub fn set_position(&mut self, position: Option<usize>) {
+        self.position = position;
+    }
+
     /// Auto formats the key.
     pub fn fmt(&mut self) {
         self.repr = None;
@@ -190,6 +208,7 @@ impl Clone for Key {
             repr: self.repr.clone(),
             leaf_decor: self.leaf_decor.clone(),
             dotted_decor: self.dotted_decor.clone(),
+            position: self.position.clone(),
         }
     }
 }

--- a/crates/toml_edit/src/parser/inline_table.rs
+++ b/crates/toml_edit/src/parser/inline_table.rs
@@ -40,7 +40,8 @@ fn table_from_pairs(
     // Assuming almost all pairs will be directly in `root`
     root.items.reserve(v.len());
 
-    for (path, (key, value)) in v {
+    for (position, (path, (mut key, value))) in v.into_iter().enumerate() {
+        key.set_position(Some(position));
         let table = descend_path(&mut root, &path)?;
 
         // "Likewise, using dotted keys to redefine tables already defined in [table] form is not allowed"
@@ -162,6 +163,7 @@ mod test {
             r#"{a = 1e165}"#,
             r#"{ hello = "world", a = 1}"#,
             r#"{ hello.world = "a" }"#,
+            r#"{ hello.world = "a", goodbye = "b", hello.moon = "c" }"#,
         ];
         for input in inputs {
             dbg!(input);

--- a/crates/toml_edit/src/parser/mod.rs
+++ b/crates/toml_edit/src/parser/mod.rs
@@ -217,6 +217,10 @@ key = "value"
 "#,
             r#"hello.world = "a"
 "#,
+            r#"hello.world = "a"
+goodbye = "b"
+hello.moon = "c"
+"#,
             r#"foo = 1979-05-27 # Comment
 "#,
         ];

--- a/crates/toml_edit/src/parser/state.rs
+++ b/crates/toml_edit/src/parser/state.rs
@@ -7,6 +7,8 @@ pub(crate) struct ParseState {
     root: Table,
     trailing: Option<std::ops::Range<usize>>,
     current_table_position: usize,
+    // Current position within a table, to help order dotted keys
+    current_value_position: usize,
     current_table: Table,
     current_is_array: bool,
     current_table_path: Vec<Key>,
@@ -20,6 +22,7 @@ impl ParseState {
             root: Table::new(),
             trailing: None,
             current_table_position: 0,
+            current_value_position: 0,
             current_table: root,
             current_is_array: false,
             current_table_path: Vec::new(),
@@ -74,6 +77,9 @@ impl ParseState {
         if let (Some(existing), Some(value)) = (self.current_table.span(), value.span()) {
             self.current_table.span = Some((existing.start)..(value.end));
         }
+        key.set_position(Some(self.current_value_position));
+        self.current_value_position += 1;
+
         let table = &mut self.current_table;
         let table = Self::descend_path(table, &path, true)?;
 
@@ -161,6 +167,7 @@ impl ParseState {
         }
 
         self.current_table_position += 1;
+        self.current_value_position = 0;
         self.current_table.decor = decor;
         self.current_table.set_implicit(false);
         self.current_table.set_dotted(false);

--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -96,6 +96,7 @@ impl Table {
                 _ => {}
             }
         }
+        sort_values_by_position(values);
     }
 
     /// Auto formats the table.
@@ -516,6 +517,18 @@ fn decorate_table(table: &mut Table) {
         key.dotted_decor_mut().clear();
         value.decor_mut().clear();
     }
+}
+
+pub(crate) fn sort_values_by_position<'s>(values: &mut Vec<(Vec<&'s Key>, &'s Value)>) {
+    values.sort_by(|(left_kp, _), (right_kp, _)| {
+        return match (left_kp.last().map(|x| x.position),
+                      right_kp.last().map(|x| x.position)) {
+            // first if both have Some() position, its easy
+            (Some(Some(p1)), Some(Some(p2))) => p1.cmp(&p2),
+            // if one or more do not, preserve order
+            _ => std::cmp::Ordering::Equal
+        }
+    });
 }
 
 // `key1 = value1`

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -580,6 +580,42 @@ fn test_sort_values() {
 }
 
 #[test]
+fn test_sort_dotted_values() {
+    given(
+        r#"
+        [a.z]
+
+        [a]
+        a.b = 2
+        # this comment is attached to b
+        b = 3 # as well as this
+        a.a = 1
+        c = 4
+
+        [a.y]"#,
+    )
+        .running(|root| {
+            let a = root.get_mut("a").unwrap();
+            let a = as_table!(a);
+            a.sort_values();
+        })
+        .produces_display(str![[r#"
+
+        [a.z]
+
+        [a]
+        a.a = 1
+        a.b = 2
+        # this comment is attached to b
+        b = 3 # as well as this
+        c = 4
+
+        [a.y]
+
+"#]]);
+}
+
+#[test]
 fn test_sort_values_by() {
     given(
         r#"

--- a/crates/toml_edit/tests/testsuite/parse.rs
+++ b/crates/toml_edit/tests/testsuite/parse.rs
@@ -1606,6 +1606,25 @@ clippy.exhaustive_enums = "warn"
 }
 
 #[test]
+fn dotted_key_interspersed_roundtrip() {
+    let input = r###"
+rust.unsafe_op_in_unsafe_fn = "deny"
+
+clippy.cast_lossless = "warn"
+rust.explicit_outlives_requirements = "warn"
+
+clippy.doc_markdown = "warn"
+clippy.exhaustive_enums = "warn"
+"###;
+    let expected = input;
+
+    let manifest: DocumentMut = input.parse().unwrap();
+    let actual = manifest.to_string();
+
+    assert_data_eq!(actual, expected.raw());
+}
+
+#[test]
 fn string_repr_roundtrip() {
     assert_string_repr_roundtrip(r#""""#, str![[r#""""#]]);
     assert_string_repr_roundtrip(r#""a""#, str![[r#""a""#]]);


### PR DESCRIPTION
Fixes #163

Based on @epage's WIP work from #165.

Admittedly not the most efficient solution as it adds another `Vec::sort_by` to the `Table::append_values` and `InlineTable::append_values` functions, sorting the `Vec`s after the values have just been inserted into them.

The slightly more efficient `Vec::sort_by_key` is not necessarily possible since it might move non-dotted keys all together, thus again breaking the original document's order.

A better solution might be to insert the values into the values `Vec`s in the intended order, but this would be much more involved.

Note:
This change failed some tests from the `edit` functionality, specifically, `Table::{sort_values, sort_values_by}` and the `InlineTable` versions. So, I created a targeted fix for that, where it just sets the `Key.position` property to be the index in the iterator over its keys.

The implication here is that any future changes that involve key re-orderings on Tables will have to modify `Key.position` value, instead of just their order in the `items: IndexMap`. 

In fact, because of this, we could remove the ordering of the `IndexMap` completely now, and instead rely on the position value, thereby reducing the chances of future confusion.

Without a more comprehensive change like that, I have a feeling there might be an untested use case here somewhere, if something else I'm not aware of is modifying the `Key` order in `Table.items` or `InlineTable.items`, then this will now fail.