### PR TITLE
docs: Document that `toml!` macro allows external identifiers and Rust expressions

### DIFF
--- a/crates/toml/src/macros.rs
+++ b/crates/toml/src/macros.rs
@@ -19,6 +19,17 @@ use crate::value::{Array, Table, Value};
 ///
 /// println!("{:#?}", cargo_toml);
 /// ```
+///
+/// External identifiers and Rust expressions (between parentheses) are allowed.
+///
+/// ```rust
+/// let some_value = "Hello, world!";
+/// let toml_doc = toml::toml! {
+///     external_ident = some_value
+///     rust_expr = (u16::MAX - 1)
+/// };
+/// println!("{:#?}", toml_doc);
+/// ```
 #[macro_export]
 macro_rules! toml {
     ($($toml:tt)+) => {{


### PR DESCRIPTION
I found it empirically, so I think it would be nice if documentation mentions it.