### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/toml/README.md
+++ b/crates/toml/README.md
@@ -5,7 +5,7 @@
 
 A [serde]-compatible [TOML][toml] decoder and encoder for Rust.
 
-For format-preserving edits or finer control over output, see [toml_edit]
+For format-preserving editing or finer control over output, see [toml_edit]
 
 [serde]: https://serde.rs/
 [toml]: https://github.com/toml-lang/toml
@@ -26,4 +26,4 @@ at your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in toml-rs by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.
+dual-licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

Description correction:
Corrected `edits` to `editing`
Corrected `dual licensed` to `dual-licensed`

Please review the changes and let me know if any additional changes are needed.