### PR TITLE
Remove Debug nesting in errors that only contain an `inner` error

### DIFF
--- a/crates/toml/src/de.rs
+++ b/crates/toml/src/de.rs
@@ -46,7 +46,7 @@ where
 }
 
 /// Errors that can occur when deserializing a type.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Error {
     inner: crate::edit::de::Error,
 }
@@ -82,6 +82,12 @@ impl serde::de::Error for Error {
 }
 
 impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl std::fmt::Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.inner.fmt(f)
     }

--- a/crates/toml/src/ser.rs
+++ b/crates/toml/src/ser.rs
@@ -74,7 +74,7 @@ where
 }
 
 /// Errors that can occur when serializing a type.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Error {
     pub(crate) inner: crate::edit::ser::Error,
 }
@@ -120,6 +120,12 @@ impl serde::ser::Error for Error {
 }
 
 impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl std::fmt::Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.inner.fmt(f)
     }

--- a/crates/toml_edit/src/de/mod.rs
+++ b/crates/toml_edit/src/de/mod.rs
@@ -21,7 +21,7 @@ use table_enum::TableEnumDeserializer;
 pub use value::ValueDeserializer;
 
 /// Errors that can occur when deserializing a type.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Error {
     inner: crate::TomlError,
 }
@@ -66,6 +66,12 @@ impl serde::de::Error for Error {
 }
 
 impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl std::fmt::Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.inner.fmt(f)
     }


### PR DESCRIPTION
```rust
fn main() {
    println!("{:#?}", toml::from_str::<i32>("").unwrap_err());
}
```

Before:

```console
Error {
    inner: Error {
        inner: TomlError {
            message: "invalid type: map, expected i32",
            raw: Some(
                "",
            ),
            keys: [],
            span: Some(
                0..0,
            ),
        },
    },
}
```

After:

```console
TomlError {
    message: "invalid type: map, expected i32",
    raw: Some(
        "",
    ),
    keys: [],
    span: Some(
        0..0,
    ),
}
```