### PR TITLE
Resolve Winnow deprecations

### DIFF
--- a/crates/toml_edit/src/parser/mod.rs
+++ b/crates/toml_edit/src/parser/mod.rs
@@ -86,11 +86,11 @@ pub(crate) mod prelude {
     pub(crate) use winnow::PResult;
     pub(crate) use winnow::Parser;
 
-    pub(crate) type Input<'b> = winnow::Stateful<winnow::Located<&'b winnow::BStr>, RecursionCheck>;
+    pub(crate) type Input<'b> = winnow::Stateful<winnow::stream::Located<&'b winnow::BStr>, RecursionCheck>;
 
     pub(crate) fn new_input(s: &str) -> Input<'_> {
         winnow::Stateful {
-            input: winnow::Located::new(winnow::BStr::new(s)),
+            input: winnow::stream::Located::new(winnow::BStr::new(s)),
             state: Default::default(),
         }
     }


### PR DESCRIPTION
winnow-0.6.23 contains incompatible changes: "Located" no more top-crate re-export.

fixed by using "stream::Located" instead.