### PR TITLE
docs(readme): Update example to prefer DocumentMut

### DIFF
--- a/crates/toml_edit/README.md
+++ b/crates/toml_edit/README.md
@@ -16,14 +16,14 @@ relative order* of items.
 ## Example
 
 ```rust
-use toml_edit::{Document, value};
+use toml_edit::{DocumentMut, value};
 
 fn main() {
     let toml = r#"
 "hello" = 'toml!' # comment
 ['a'.b]
     "#;
-    let mut doc = toml.parse::<Document>().expect("invalid doc");
+    let mut doc = toml.parse::<DocumentMut>().expect("invalid doc");
     assert_eq!(doc.to_string(), toml);
     // let's add a new key/value pair inside a.b: c = {d = "hello"}
     doc["a"]["b"]["c"]["d"] = value("hello");


### PR DESCRIPTION
Thanks for these great crates! I noticed that `Document` is deprecated but is used in [the example of the toml_edit/README](https://github.com/toml-rs/toml/blob/a07313eb8c1e9a08ecf46c108270940f12d4f0fc/crates/toml_edit/README.md). This pull request updates it to `DocumentMut`.

Note that [the similar example at the top of lib.rs](https://github.com/toml-rs/toml/blob/a07313eb8c1e9a08ecf46c108270940f12d4f0fc/crates/toml_edit/src/lib.rs#L9-L34) already uses `DocumentMut`, so <https://docs.rs/toml_edit/latest/toml_edit/#example> is good. However, the README appears in [the crates.io page](https://crates.io/crates/toml_edit). Thus this pull request is motivated.