### PR TITLE
feat: impl Map get_key_value

### DIFF
--- a/crates/toml/src/map.rs
+++ b/crates/toml/src/map.rs
@@ -112,6 +112,19 @@ impl Map<String, Value> {
         self.map.get_mut(key)
     }
 
+    /// Returns the key-value pair matching the given key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but the ordering
+    /// on the borrowed form *must* match the ordering on the key type.
+    #[inline]
+    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&String, &Value)>
+    where
+        String: Borrow<Q>,
+        Q: ?Sized + Ord + Eq + Hash,
+    {
+        self.map.get_key_value(key)
+    }
+
     /// Inserts a key-value pair into the map.
     ///
     /// If the map did not have this key present, `None` is returned.


### PR DESCRIPTION
@epage 

This is brought from `serde_json`'s impl.

It helps when you want to tell the compiler that the key (&String) has the same lifetime to `&self`, while using the input `key: &Q` doesn't have this bound.

I found this while implementing https://github.com/cratesland/spath/pull/20/