### PR TITLE
fix: Remove hack for serializing Values

### DIFF
--- a/crates/toml/tests/serde/pretty.rs
+++ b/crates/toml/tests/serde/pretty.rs
@@ -146,14 +146,14 @@ this is the fourth line
 
 #[test]
 fn pretty_table_array() {
-    let toml = r#"[[array]]
+    let toml = r#"[abc]
+doc = "this is a table"
+
+[[array]]
 key = "foo"
 
 [[array]]
 key = "bar"
-
-[abc]
-doc = "this is a table"
 
 [example]
 single = "this is a single line string"
@@ -167,14 +167,14 @@ single = "this is a single line string"
     assert_data_eq!(
         &result,
         str![[r#"
+[abc]
+doc = "this is a table"
+
 [[array]]
 key = "foo"
 
 [[array]]
 key = "bar"
-
-[abc]
-doc = "this is a table"
 
 [example]
 single = "this is a single line string"
@@ -185,14 +185,14 @@ single = "this is a single line string"
 
 #[test]
 fn no_pretty_table_array() {
-    let toml = r#"[[array]]
+    let toml = r#"[abc]
+doc = "this is a table"
+
+[[array]]
 key = "foo"
 
 [[array]]
 key = "bar"
-
-[abc]
-doc = "this is a table"
 
 [example]
 single = "this is a single line string"
@@ -204,14 +204,14 @@ single = "this is a single line string"
     assert_data_eq!(
         &result,
         str![[r#"
+[abc]
+doc = "this is a table"
+
 [[array]]
 key = "foo"
 
 [[array]]
 key = "bar"
-
-[abc]
-doc = "this is a table"
 
 [example]
 single = "this is a single line string"


### PR DESCRIPTION
This was to avoid writing key-value pairs for a table after children tables are written.
However, using `toml_edit`, this is taken care of for us.

This causesx a table ordering that doesn't happen otherwise