### PR TITLE
fix(serde): Skip fields with newtypes wrapping None 

### DIFF
--- a/crates/toml/tests/serde/general.rs
+++ b/crates/toml/tests/serde/general.rs
@@ -1558,8 +1558,19 @@ a = \"foo\"
 
     assert_eq!(value, expected);
     assert_data_eq!(
-        crate::to_string(&value).unwrap_err().to_string(),
-        str!["unsupported None value"].raw()
+        crate::to_string(&value).unwrap(),
+        str![[r#"
+[bar]
+
+[baz]
+
+[bazv]
+a = "foo"
+
+[foo]
+
+"#]]
+        .raw()
     );
 }
 

--- a/crates/toml/tests/serde/general.rs
+++ b/crates/toml/tests/serde/general.rs
@@ -175,43 +175,6 @@ fn array() {
 }
 
 #[test]
-fn inner_structs_with_options() {
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Foo {
-        a: Option<Box<Foo>>,
-        b: Bar,
-    }
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Bar {
-        a: String,
-        b: f64,
-    }
-
-    equivalent! {
-        Foo {
-            a: Some(Box::new(Foo {
-                a: None,
-                b: Bar { a: "foo".to_owned(), b: 4.5 },
-            })),
-            b: Bar { a: "bar".to_owned(), b: 1.0 },
-        },
-        map! {
-            a: map! {
-                b: map! {
-                    a: crate::SerdeValue::String("foo".to_owned()),
-                    b: crate::SerdeValue::Float(4.5)
-                }
-            },
-            b: map! {
-                a: crate::SerdeValue::String("bar".to_owned()),
-                b: crate::SerdeValue::Float(1.0)
-            }
-        },
-    }
-}
-
-#[test]
-#[cfg(feature = "preserve_order")]
 fn hashmap() {
     use std::collections::HashSet;
 
@@ -674,26 +637,6 @@ fn empty_arrays() {
 }
 
 #[test]
-fn empty_arrays2() {
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Foo {
-        a: Option<Vec<Bar>>,
-    }
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Bar;
-
-    equivalent! {
-        Foo { a: None },
-        map! {},
-    }
-
-    equivalent! {
-        Foo { a: Some(vec![]) },
-        map! { a: crate::SerdeValue::Array(vec![]) },
-    }
-}
-
-#[test]
 fn extra_keys() {
     #[derive(Serialize, Deserialize)]
     struct Foo {
@@ -789,44 +732,6 @@ fn newtype_key() {
             y: crate::SerdeValue::Integer(2)
         },
     }
-}
-
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
-struct CanBeEmpty {
-    a: Option<String>,
-    b: Option<String>,
-}
-
-#[test]
-fn table_structs_empty() {
-    let input = "[bar]\n\n[baz]\n\n[bazv]\na = \"foo\"\n\n[foo]\n";
-    let value: BTreeMap<String, CanBeEmpty> = crate::from_str(input).unwrap();
-    let mut expected: BTreeMap<String, CanBeEmpty> = BTreeMap::new();
-    expected.insert("bar".to_owned(), CanBeEmpty::default());
-    expected.insert("baz".to_owned(), CanBeEmpty::default());
-    expected.insert(
-        "bazv".to_owned(),
-        CanBeEmpty {
-            a: Some("foo".to_owned()),
-            b: None,
-        },
-    );
-    expected.insert("foo".to_owned(), CanBeEmpty::default());
-    assert_eq!(value, expected);
-    assert_data_eq!(
-        crate::to_string(&value).unwrap(),
-        str![[r#"
-[bar]
-
-[baz]
-
-[bazv]
-a = "foo"
-
-[foo]
-
-"#]]
-    );
 }
 
 #[test]
@@ -1510,6 +1415,110 @@ values = [{ Optional = { x = 0, y = 4 } }, "Empty", { Optional = { x = 2, y = 5 
 values = [{ Optional = { x = 0, y = 4 } }, "Empty", { Optional = { x = 2 } }, { Optional = { x = 3, y = 7 } }]
 
 "#]].raw());
+}
+
+#[test]
+fn serialize_struct_with_none_string() {
+    #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+    struct CanBeEmpty {
+        a: Option<String>,
+        b: Option<String>,
+    }
+
+    let input = "[bar]
+
+[baz]
+
+[bazv]
+a = \"foo\"
+
+[foo]";
+    let value: BTreeMap<String, CanBeEmpty> = crate::from_str(input).unwrap();
+
+    let mut expected: BTreeMap<String, CanBeEmpty> = BTreeMap::new();
+    expected.insert("bar".to_owned(), CanBeEmpty::default());
+    expected.insert("baz".to_owned(), CanBeEmpty::default());
+    expected.insert(
+        "bazv".to_owned(),
+        CanBeEmpty {
+            a: Some("foo".to_owned()),
+            b: None,
+        },
+    );
+    expected.insert("foo".to_owned(), CanBeEmpty::default());
+
+    assert_eq!(value, expected);
+    assert_data_eq!(
+        crate::to_string(&value).unwrap(),
+        str![[r#"
+[bar]
+
+[baz]
+
+[bazv]
+a = "foo"
+
+[foo]
+
+"#]]
+        .raw()
+    );
+}
+
+#[test]
+fn serialize_struct_with_none_vec() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Foo {
+        a: Option<Vec<Bar>>,
+    }
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Bar;
+
+    equivalent! {
+        Foo { a: None },
+        map! {},
+    }
+
+    equivalent! {
+        Foo { a: Some(vec![]) },
+        map! { a: crate::SerdeValue::Array(vec![]) },
+    }
+}
+
+#[test]
+fn serialize_struct_with_none_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Foo {
+        a: Option<Box<Foo>>,
+        b: Bar,
+    }
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Bar {
+        a: String,
+        b: f64,
+    }
+
+    equivalent! {
+        Foo {
+            a: Some(Box::new(Foo {
+                a: None,
+                b: Bar { a: "foo".to_owned(), b: 4.5 },
+            })),
+            b: Bar { a: "bar".to_owned(), b: 1.0 },
+        },
+        map! {
+            a: map! {
+                b: map! {
+                    a: crate::SerdeValue::String("foo".to_owned()),
+                    b: crate::SerdeValue::Float(4.5)
+                }
+            },
+            b: map! {
+                a: crate::SerdeValue::String("bar".to_owned()),
+                b: crate::SerdeValue::Float(1.0)
+            }
+        },
+    }
 }
 
 #[test]

--- a/crates/toml/tests/serde/general.rs
+++ b/crates/toml/tests/serde/general.rs
@@ -1522,6 +1522,48 @@ fn serialize_struct_with_none_struct() {
 }
 
 #[test]
+fn serialize_struct_with_newtype_with_none() {
+    #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+    struct CanBeEmpty {
+        #[serde(default)]
+        a: NewType,
+        #[serde(default)]
+        b: NewType,
+    }
+
+    #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+    struct NewType(Option<String>);
+
+    let input = "[bar]
+
+[baz]
+
+[bazv]
+a = \"foo\"
+
+[foo]";
+    let value: BTreeMap<String, CanBeEmpty> = crate::from_str(input).unwrap();
+
+    let mut expected: BTreeMap<String, CanBeEmpty> = BTreeMap::new();
+    expected.insert("bar".to_owned(), CanBeEmpty::default());
+    expected.insert("baz".to_owned(), CanBeEmpty::default());
+    expected.insert(
+        "bazv".to_owned(),
+        CanBeEmpty {
+            a: NewType(Some("foo".to_owned())),
+            b: NewType(None),
+        },
+    );
+    expected.insert("foo".to_owned(), CanBeEmpty::default());
+
+    assert_eq!(value, expected);
+    assert_data_eq!(
+        crate::to_string(&value).unwrap_err().to_string(),
+        str!["unsupported None value"].raw()
+    );
+}
+
+#[test]
 fn span_for_sequence_as_map() {
     #[allow(dead_code)]
     #[derive(Deserialize)]

--- a/crates/toml_edit/src/ser/array.rs
+++ b/crates/toml_edit/src/ser/array.rs
@@ -83,12 +83,10 @@ impl serde::ser::SerializeTupleStruct for SerializeValueArray {
     }
 }
 
-pub struct SerializeVariant<T> {
+pub struct SerializeTupleVariant {
     variant: &'static str,
-    inner: T,
+    inner: SerializeValueArray,
 }
-
-pub(crate) type SerializeTupleVariant = SerializeVariant<SerializeValueArray>;
 
 impl SerializeTupleVariant {
     pub(crate) fn tuple(variant: &'static str, len: usize) -> Self {

--- a/crates/toml_edit/src/ser/array.rs
+++ b/crates/toml_edit/src/ser/array.rs
@@ -82,3 +82,41 @@ impl serde::ser::SerializeTupleStruct for SerializeValueArray {
         serde::ser::SerializeSeq::end(self)
     }
 }
+
+pub struct SerializeVariant<T> {
+    variant: &'static str,
+    inner: T,
+}
+
+pub(crate) type SerializeTupleVariant = SerializeVariant<SerializeValueArray>;
+
+impl SerializeTupleVariant {
+    pub(crate) fn tuple(variant: &'static str, len: usize) -> Self {
+        Self {
+            variant,
+            inner: SerializeValueArray::with_capacity(len),
+        }
+    }
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
+    type Ok = crate::Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: serde::ser::Serialize + ?Sized,
+    {
+        serde::ser::SerializeSeq::serialize_element(&mut self.inner, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let inner = serde::ser::SerializeSeq::end(self.inner)?;
+        let mut items = crate::table::KeyValuePairs::new();
+        let value = crate::Item::Value(inner);
+        items.insert(crate::Key::new(self.variant), value);
+        Ok(crate::Value::InlineTable(crate::InlineTable::with_pairs(
+            items,
+        )))
+    }
+}

--- a/crates/toml_edit/src/ser/map.rs
+++ b/crates/toml_edit/src/ser/map.rs
@@ -570,28 +570,18 @@ impl serde::ser::Serializer for &mut MapValueSerializer {
     }
 }
 
-pub(crate) type SerializeTupleVariant = SerializeVariant<SerializeValueArray>;
-pub(crate) type SerializeStructVariant = SerializeVariant<SerializeMap>;
-
 pub struct SerializeVariant<T> {
     variant: &'static str,
     inner: T,
 }
+
+pub(crate) type SerializeTupleVariant = SerializeVariant<SerializeValueArray>;
 
 impl SerializeTupleVariant {
     pub(crate) fn tuple(variant: &'static str, len: usize) -> Self {
         Self {
             variant,
             inner: SerializeValueArray::with_capacity(len),
-        }
-    }
-}
-
-impl SerializeStructVariant {
-    pub(crate) fn struct_(variant: &'static str, len: usize) -> Self {
-        Self {
-            variant,
-            inner: SerializeMap::table_with_capacity(len),
         }
     }
 }
@@ -615,6 +605,17 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
         Ok(crate::Value::InlineTable(crate::InlineTable::with_pairs(
             items,
         )))
+    }
+}
+
+pub(crate) type SerializeStructVariant = SerializeVariant<SerializeMap>;
+
+impl SerializeStructVariant {
+    pub(crate) fn struct_(variant: &'static str, len: usize) -> Self {
+        Self {
+            variant,
+            inner: SerializeMap::table_with_capacity(len),
+        }
     }
 }
 

--- a/crates/toml_edit/src/ser/map.rs
+++ b/crates/toml_edit/src/ser/map.rs
@@ -502,13 +502,13 @@ impl serde::ser::Serializer for MapValueSerializer<'_> {
 
     fn serialize_newtype_struct<T>(
         self,
-        name: &'static str,
+        _name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: serde::ser::Serialize + ?Sized,
     {
-        ValueSerializer::new().serialize_newtype_struct(name, value)
+        value.serialize(self)
     }
 
     fn serialize_newtype_variant<T>(

--- a/crates/toml_edit/src/ser/map.rs
+++ b/crates/toml_edit/src/ser/map.rs
@@ -573,14 +573,14 @@ impl serde::ser::Serializer for &mut MapValueSerializer {
 
 pub struct SerializeStructVariant {
     variant: &'static str,
-    inner: SerializeMap,
+    inner: SerializeInlineTable,
 }
 
 impl SerializeStructVariant {
     pub(crate) fn struct_(variant: &'static str, len: usize) -> Self {
         Self {
             variant,
-            inner: SerializeMap::table_with_capacity(len),
+            inner: SerializeInlineTable::with_capacity(len),
         }
     }
 }
@@ -599,7 +599,7 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        let inner = serde::ser::SerializeStruct::end(self.inner)?;
+        let inner = serde::ser::SerializeStruct::end(self.inner)?.into();
         let mut items = crate::table::KeyValuePairs::new();
         let value = crate::Item::Value(inner);
         items.insert(crate::Key::new(self.variant), value);

--- a/crates/toml_edit/src/ser/map.rs
+++ b/crates/toml_edit/src/ser/map.rs
@@ -596,7 +596,7 @@ impl SerializeStructVariant {
     }
 }
 
-impl serde::ser::SerializeTupleVariant for SerializeVariant<SerializeValueArray> {
+impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     type Ok = crate::Value;
     type Error = Error;
 
@@ -618,7 +618,7 @@ impl serde::ser::SerializeTupleVariant for SerializeVariant<SerializeValueArray>
     }
 }
 
-impl serde::ser::SerializeStructVariant for SerializeVariant<SerializeMap> {
+impl serde::ser::SerializeStructVariant for SerializeStructVariant {
     type Ok = crate::Value;
     type Error = Error;
 

--- a/crates/toml_edit/src/ser/map.rs
+++ b/crates/toml_edit/src/ser/map.rs
@@ -571,12 +571,10 @@ impl serde::ser::Serializer for &mut MapValueSerializer {
     }
 }
 
-pub struct SerializeVariant<T> {
+pub struct SerializeStructVariant {
     variant: &'static str,
-    inner: T,
+    inner: SerializeMap,
 }
-
-pub(crate) type SerializeStructVariant = SerializeVariant<SerializeMap>;
 
 impl SerializeStructVariant {
     pub(crate) fn struct_(variant: &'static str, len: usize) -> Self {

--- a/crates/toml_edit/src/ser/map.rs
+++ b/crates/toml_edit/src/ser/map.rs
@@ -1,3 +1,4 @@
+use super::array::SerializeTupleVariant;
 use super::array::SerializeValueArray;
 use super::key::KeySerializer;
 use super::value::ValueSerializer;
@@ -573,39 +574,6 @@ impl serde::ser::Serializer for &mut MapValueSerializer {
 pub struct SerializeVariant<T> {
     variant: &'static str,
     inner: T,
-}
-
-pub(crate) type SerializeTupleVariant = SerializeVariant<SerializeValueArray>;
-
-impl SerializeTupleVariant {
-    pub(crate) fn tuple(variant: &'static str, len: usize) -> Self {
-        Self {
-            variant,
-            inner: SerializeValueArray::with_capacity(len),
-        }
-    }
-}
-
-impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
-    type Ok = crate::Value;
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
-    where
-        T: serde::ser::Serialize + ?Sized,
-    {
-        serde::ser::SerializeSeq::serialize_element(&mut self.inner, value)
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        let inner = serde::ser::SerializeSeq::end(self.inner)?;
-        let mut items = crate::table::KeyValuePairs::new();
-        let value = crate::Item::Value(inner);
-        items.insert(crate::Key::new(self.variant), value);
-        Ok(crate::Value::InlineTable(crate::InlineTable::with_pairs(
-            items,
-        )))
-    }
 }
 
 pub(crate) type SerializeStructVariant = SerializeVariant<SerializeMap>;

--- a/crates/toml_edit/src/ser/value.rs
+++ b/crates/toml_edit/src/ser/value.rs
@@ -64,7 +64,7 @@ impl serde::ser::Serializer for ValueSerializer {
     type SerializeSeq = super::array::SerializeValueArray;
     type SerializeTuple = super::array::SerializeValueArray;
     type SerializeTupleStruct = super::array::SerializeValueArray;
-    type SerializeTupleVariant = super::map::SerializeTupleVariant;
+    type SerializeTupleVariant = super::array::SerializeTupleVariant;
     type SerializeMap = super::map::SerializeMap;
     type SerializeStruct = super::map::SerializeMap;
     type SerializeStructVariant = super::map::SerializeStructVariant;
@@ -222,7 +222,7 @@ impl serde::ser::Serializer for ValueSerializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Ok(super::map::SerializeTupleVariant::tuple(variant, len))
+        Ok(super::array::SerializeTupleVariant::tuple(variant, len))
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {

--- a/crates/toml_edit/tests/serde/general.rs
+++ b/crates/toml_edit/tests/serde/general.rs
@@ -156,42 +156,6 @@ fn array() {
 }
 
 #[test]
-fn inner_structs_with_options() {
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Foo {
-        a: Option<Box<Foo>>,
-        b: Bar,
-    }
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Bar {
-        a: String,
-        b: f64,
-    }
-
-    equivalent! {
-        Foo {
-            a: Some(Box::new(Foo {
-                a: None,
-                b: Bar { a: "foo".to_owned(), b: 4.5 },
-            })),
-            b: Bar { a: "bar".to_owned(), b: 1.0 },
-        },
-        map! {
-            a: map! {
-                b: map! {
-                    a: crate::SerdeValue::String("foo".to_owned()),
-                    b: crate::SerdeValue::Float(4.5)
-                }
-            },
-            b: map! {
-                a: crate::SerdeValue::String("bar".to_owned()),
-                b: crate::SerdeValue::Float(1.0)
-            }
-        },
-    }
-}
-
-#[test]
 fn hashmap() {
     use std::collections::HashSet;
 
@@ -639,26 +603,6 @@ fn empty_arrays() {
 }
 
 #[test]
-fn empty_arrays2() {
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Foo {
-        a: Option<Vec<Bar>>,
-    }
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Bar;
-
-    equivalent! {
-        Foo { a: None },
-        map! {},
-    }
-
-    equivalent! {
-        Foo { a: Some(vec![]) },
-        map! { a: crate::SerdeValue::Array(vec![]) },
-    }
-}
-
-#[test]
 fn extra_keys() {
     #[derive(Serialize, Deserialize)]
     struct Foo {
@@ -754,41 +698,6 @@ fn newtype_key() {
             y: crate::SerdeValue::Integer(2)
         },
     }
-}
-
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
-struct CanBeEmpty {
-    a: Option<String>,
-    b: Option<String>,
-}
-
-#[test]
-fn table_structs_empty() {
-    let input = "[bar]\n\n[baz]\n\n[bazv]\na = \"foo\"\n\n[foo]\n";
-    let value: BTreeMap<String, CanBeEmpty> = crate::from_str(input).unwrap();
-    let mut expected: BTreeMap<String, CanBeEmpty> = BTreeMap::new();
-    expected.insert("bar".to_owned(), CanBeEmpty::default());
-    expected.insert("baz".to_owned(), CanBeEmpty::default());
-    expected.insert(
-        "bazv".to_owned(),
-        CanBeEmpty {
-            a: Some("foo".to_owned()),
-            b: None,
-        },
-    );
-    expected.insert("foo".to_owned(), CanBeEmpty::default());
-    assert_eq!(value, expected);
-    assert_data_eq!(
-        crate::to_string(&value).unwrap(),
-        str![[r#"
-bar = {}
-baz = {}
-bazv = { a = "foo" }
-foo = {}
-
-"#]]
-        .raw()
-    );
 }
 
 #[test]
@@ -1453,6 +1362,106 @@ values = [{ Optional = { x = 0, y = 4 } }, "Empty", { Optional = { x = 2, y = 5 
 values = [{ Optional = { x = 0, y = 4 } }, "Empty", { Optional = { x = 2 } }, { Optional = { x = 3, y = 7 } }]
 
 "#]].raw());
+}
+
+#[test]
+fn serialize_struct_with_none_string() {
+    #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+    struct CanBeEmpty {
+        a: Option<String>,
+        b: Option<String>,
+    }
+
+    let input = "[bar]
+
+[baz]
+
+[bazv]
+a = \"foo\"
+
+[foo]";
+    let value: BTreeMap<String, CanBeEmpty> = crate::from_str(input).unwrap();
+
+    let mut expected: BTreeMap<String, CanBeEmpty> = BTreeMap::new();
+    expected.insert("bar".to_owned(), CanBeEmpty::default());
+    expected.insert("baz".to_owned(), CanBeEmpty::default());
+    expected.insert(
+        "bazv".to_owned(),
+        CanBeEmpty {
+            a: Some("foo".to_owned()),
+            b: None,
+        },
+    );
+    expected.insert("foo".to_owned(), CanBeEmpty::default());
+
+    assert_eq!(value, expected);
+    assert_data_eq!(
+        crate::to_string(&value).unwrap(),
+        str![[r#"
+bar = {}
+baz = {}
+bazv = { a = "foo" }
+foo = {}
+
+"#]]
+        .raw()
+    );
+}
+
+#[test]
+fn serialize_struct_with_none_vec() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Foo {
+        a: Option<Vec<Bar>>,
+    }
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Bar;
+
+    equivalent! {
+        Foo { a: None },
+        map! {},
+    }
+
+    equivalent! {
+        Foo { a: Some(vec![]) },
+        map! { a: crate::SerdeValue::Array(vec![]) },
+    }
+}
+
+#[test]
+fn serialize_struct_with_none_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Foo {
+        a: Option<Box<Foo>>,
+        b: Bar,
+    }
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Bar {
+        a: String,
+        b: f64,
+    }
+
+    equivalent! {
+        Foo {
+            a: Some(Box::new(Foo {
+                a: None,
+                b: Bar { a: "foo".to_owned(), b: 4.5 },
+            })),
+            b: Bar { a: "bar".to_owned(), b: 1.0 },
+        },
+        map! {
+            a: map! {
+                b: map! {
+                    a: crate::SerdeValue::String("foo".to_owned()),
+                    b: crate::SerdeValue::Float(4.5)
+                }
+            },
+            b: map! {
+                a: crate::SerdeValue::String("bar".to_owned()),
+                b: crate::SerdeValue::Float(1.0)
+            }
+        },
+    }
 }
 
 #[test]

--- a/crates/toml_edit/tests/serde/general.rs
+++ b/crates/toml_edit/tests/serde/general.rs
@@ -1501,8 +1501,15 @@ a = \"foo\"
 
     assert_eq!(value, expected);
     assert_data_eq!(
-        crate::to_string(&value).unwrap_err().to_string(),
-        str!["unsupported None value"].raw()
+        crate::to_string(&value).unwrap(),
+        str![[r#"
+bar = {}
+baz = {}
+bazv = { a = "foo" }
+foo = {}
+
+"#]]
+        .raw()
     );
 }
 

--- a/crates/toml_write/src/lib.rs
+++ b/crates/toml_write/src/lib.rs
@@ -1,5 +1,25 @@
 //! A low-level interface for writing out TOML
 //!
+//! Considerations when serializing arbitrary data:
+//! - Verify the implementation with [`toml-test-harness`](https://docs.rs/toml-test-harness)
+//! - Be sure to group keys under a table before writing another table
+//! - Watch for extra trailing newlines and leading newlines, both when starting with top-level
+//!   keys or a table
+//! - When serializing an array-of-tables, be sure to verify that all elements of the array
+//!   serialize as tables
+//! - Standard tables and inline tables may need separate implementations of corner cases,
+//!   requiring verifying them both
+//!
+//! When serializing Rust data structures
+//! - `Option`: Skip key-value pairs with a value of `None`, otherwise error when seeing `None`
+//!   - When skipping key-value pairs, be careful that a deeply nested `None` doesn't get skipped
+//! - Scalars and arrays are unsupported as top-level data types
+//! - Tuples and tuple variants seriallize as arrays
+//! - Structs, struct variants, and maps serialize as tables
+//! - Newtype variants serialize as to the inner type
+//! - Unit variants serialize to a string
+//! - Unit and unit structs don't have a clear meaning in TOML
+//!
 //! # Example
 //!
 //! ```rust


### PR DESCRIPTION
I think this change is justifiable because it makes the `Option<T>` and
`NewtypeOption<T>` cases have the same analogeous behavior as
`serde_json`
- `serde_json` serializes both to `null`
- `toml` serializes both to a non-existent field
- `serde_json` and `toml` require `#[serde(default)]` for deserialization of `NewtypeOption<T>`

The rest is part of cleanup in prep for `toml` to call `toml_write`