### PR TITLE
fix(serde): Serialize deserializable content

### DIFF
--- a/crates/toml/src/ser/array.rs
+++ b/crates/toml/src/ser/array.rs
@@ -54,7 +54,7 @@ impl serde::ser::SerializeTuple for SerializeDocumentArray<'_> {
     }
 }
 
-impl serde::ser::SerializeTupleVariant for SerializeDocumentArray<'_> {
+impl serde::ser::SerializeTupleStruct for SerializeDocumentArray<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -70,7 +70,27 @@ impl serde::ser::SerializeTupleVariant for SerializeDocumentArray<'_> {
     }
 }
 
-impl serde::ser::SerializeTupleStruct for SerializeDocumentArray<'_> {
+type InnerSerializeDocumentTupleVariant =
+    <toml_edit::ser::ValueSerializer as serde::Serializer>::SerializeTupleVariant;
+
+#[doc(hidden)]
+pub struct SerializeDocumentTupleVariant<'d> {
+    inner: InnerSerializeDocumentTupleVariant,
+    dst: &'d mut String,
+    settings: DocumentFormatter,
+}
+
+impl<'d> SerializeDocumentTupleVariant<'d> {
+    pub(crate) fn new(ser: Serializer<'d>, inner: InnerSerializeDocumentTupleVariant) -> Self {
+        Self {
+            inner,
+            dst: ser.dst,
+            settings: ser.settings,
+        }
+    }
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeDocumentTupleVariant<'_> {
     type Ok = ();
     type Error = Error;
 

--- a/crates/toml/src/ser/map.rs
+++ b/crates/toml/src/ser/map.rs
@@ -60,3 +60,21 @@ impl serde::ser::SerializeStruct for SerializeDocumentTable<'_> {
         write_document(self.dst, self.settings, self.inner.end())
     }
 }
+
+impl serde::ser::SerializeStructVariant for SerializeDocumentTable<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::ser::Serialize + ?Sized,
+    {
+        serde::ser::SerializeStruct::serialize_field(self, key, value)
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeStruct::end(self)
+    }
+}

--- a/crates/toml/src/ser/map.rs
+++ b/crates/toml/src/ser/map.rs
@@ -78,3 +78,41 @@ impl serde::ser::SerializeStructVariant for SerializeDocumentTable<'_> {
         serde::ser::SerializeStruct::end(self)
     }
 }
+
+type InnerSerializeDocumentStructVariant =
+    <toml_edit::ser::ValueSerializer as serde::Serializer>::SerializeStructVariant;
+
+#[doc(hidden)]
+pub struct SerializeDocumentStructVariant<'d> {
+    inner: InnerSerializeDocumentStructVariant,
+    dst: &'d mut String,
+    settings: DocumentFormatter,
+}
+
+impl<'d> SerializeDocumentStructVariant<'d> {
+    pub(crate) fn new(ser: Serializer<'d>, inner: InnerSerializeDocumentStructVariant) -> Self {
+        Self {
+            inner,
+            dst: ser.dst,
+            settings: ser.settings,
+        }
+    }
+}
+
+impl serde::ser::SerializeStructVariant for SerializeDocumentStructVariant<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::ser::Serialize + ?Sized,
+    {
+        self.inner.serialize_field(key, value).map_err(Error::wrap)
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        write_document(self.dst, self.settings, self.inner.end())
+    }
+}

--- a/crates/toml/src/ser/mod.rs
+++ b/crates/toml/src/ser/mod.rs
@@ -194,7 +194,7 @@ impl<'d> serde::ser::Serializer for Serializer<'d> {
     type SerializeTupleVariant = array::SerializeDocumentArray<'d>;
     type SerializeMap = map::SerializeDocumentTable<'d>;
     type SerializeStruct = map::SerializeDocumentTable<'d>;
-    type SerializeStructVariant = serde::ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = map::SerializeDocumentTable<'d>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         write_document(
@@ -441,12 +441,12 @@ impl<'d> serde::ser::Serializer for Serializer<'d> {
 
     fn serialize_struct_variant(
         self,
-        name: &'static str,
+        _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
-        _len: usize,
+        len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(Error::unsupported_type(Some(name)))
+        self.serialize_map(Some(len))
     }
 }
 

--- a/crates/toml/src/ser/mod.rs
+++ b/crates/toml/src/ser/mod.rs
@@ -191,10 +191,10 @@ impl<'d> serde::ser::Serializer for Serializer<'d> {
     type SerializeSeq = array::SerializeDocumentArray<'d>;
     type SerializeTuple = array::SerializeDocumentArray<'d>;
     type SerializeTupleStruct = array::SerializeDocumentArray<'d>;
-    type SerializeTupleVariant = array::SerializeDocumentArray<'d>;
+    type SerializeTupleVariant = array::SerializeDocumentTupleVariant<'d>;
     type SerializeMap = map::SerializeDocumentTable<'d>;
     type SerializeStruct = map::SerializeDocumentTable<'d>;
-    type SerializeStructVariant = map::SerializeDocumentTable<'d>;
+    type SerializeStructVariant = map::SerializeDocumentStructVariant<'d>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         write_document(
@@ -415,12 +415,16 @@ impl<'d> serde::ser::Serializer for Serializer<'d> {
 
     fn serialize_tuple_variant(
         self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        self.serialize_seq(Some(len))
+        let ser = toml_edit::ser::ValueSerializer::new()
+            .serialize_tuple_variant(name, variant_index, variant, len)
+            .map_err(Error::wrap)?;
+        let ser = array::SerializeDocumentTupleVariant::new(self, ser);
+        Ok(ser)
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
@@ -441,12 +445,16 @@ impl<'d> serde::ser::Serializer for Serializer<'d> {
 
     fn serialize_struct_variant(
         self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        self.serialize_map(Some(len))
+        let ser = toml_edit::ser::ValueSerializer::new()
+            .serialize_struct_variant(name, variant_index, variant, len)
+            .map_err(Error::wrap)?;
+        let ser = map::SerializeDocumentStructVariant::new(self, ser);
+        Ok(ser)
     }
 }
 

--- a/crates/toml/src/ser/ser_value/array.rs
+++ b/crates/toml/src/ser/ser_value/array.rs
@@ -50,7 +50,7 @@ impl serde::ser::SerializeTuple for SerializeValueArray<'_> {
     }
 }
 
-impl serde::ser::SerializeTupleVariant for SerializeValueArray<'_> {
+impl serde::ser::SerializeTupleStruct for SerializeValueArray<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -66,7 +66,25 @@ impl serde::ser::SerializeTupleVariant for SerializeValueArray<'_> {
     }
 }
 
-impl serde::ser::SerializeTupleStruct for SerializeValueArray<'_> {
+type InnerSerializeValueTupleVariant =
+    <toml_edit::ser::ValueSerializer as serde::Serializer>::SerializeTupleVariant;
+
+#[doc(hidden)]
+pub struct SerializeValueTupleVariant<'d> {
+    inner: InnerSerializeValueTupleVariant,
+    dst: &'d mut String,
+}
+
+impl<'d> SerializeValueTupleVariant<'d> {
+    pub(crate) fn new(ser: ValueSerializer<'d>, inner: InnerSerializeValueTupleVariant) -> Self {
+        Self {
+            inner,
+            dst: ser.dst,
+        }
+    }
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeValueTupleVariant<'_> {
     type Ok = ();
     type Error = Error;
 

--- a/crates/toml/src/ser/ser_value/map.rs
+++ b/crates/toml/src/ser/ser_value/map.rs
@@ -57,3 +57,21 @@ impl serde::ser::SerializeStruct for SerializeValueTable<'_> {
         write_value(self.dst, self.inner.end())
     }
 }
+
+impl serde::ser::SerializeStructVariant for SerializeValueTable<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::ser::Serialize + ?Sized,
+    {
+        serde::ser::SerializeStruct::serialize_field(self, key, value)
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeStruct::end(self)
+    }
+}

--- a/crates/toml/src/ser/ser_value/mod.rs
+++ b/crates/toml/src/ser/ser_value/mod.rs
@@ -71,7 +71,7 @@ impl<'d> serde::ser::Serializer for ValueSerializer<'d> {
     type SerializeTupleVariant = array::SerializeValueArray<'d>;
     type SerializeMap = map::SerializeValueTable<'d>;
     type SerializeStruct = map::SerializeValueTable<'d>;
-    type SerializeStructVariant = serde::ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = map::SerializeValueTable<'d>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         write_value(
@@ -297,12 +297,12 @@ impl<'d> serde::ser::Serializer for ValueSerializer<'d> {
 
     fn serialize_struct_variant(
         self,
-        name: &'static str,
+        _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
-        _len: usize,
+        len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(Error::unsupported_type(Some(name)))
+        self.serialize_map(Some(len))
     }
 }
 

--- a/crates/toml/tests/serde/de_enum.rs
+++ b/crates/toml/tests/serde/de_enum.rs
@@ -236,21 +236,29 @@ Val {
 
     #[test]
     fn from_std_table() {
-        assert_eq!(
-            TheEnum::NewType("value".to_owned()),
-            crate::from_str(r#"NewType = "value""#).unwrap()
-        );
-        assert_eq!(
-            Val {
-                val: TheEnum::NewType("value".to_owned()),
-            },
-            crate::from_str(
-                r#"[val]
+        let result = crate::from_str::<TheEnum>(r#"NewType = "value""#);
+        let expected = str![[r#"
+NewType(
+    "value",
+)
+
+"#]];
+        assert_data_eq!(result.unwrap().to_debug(), expected);
+
+        let result = crate::from_str::<Val>(
+            r#"[val]
                 NewType = "value"
-                "#
-            )
-            .unwrap()
+                "#,
         );
+        let expected = str![[r#"
+Val {
+    val: NewType(
+        "value",
+    ),
+}
+
+"#]];
+        assert_data_eq!(result.unwrap().to_debug(), expected);
     }
 }
 

--- a/crates/toml/tests/serde/de_enum.rs
+++ b/crates/toml/tests/serde/de_enum.rs
@@ -80,7 +80,7 @@ mod enum_unit {
     use super::*;
 
     #[test]
-    fn from_str() {
+    fn value_from_str() {
         let input = "\"Plain\"";
         let expected = str![[r#"
 Plain
@@ -88,7 +88,10 @@ Plain
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_str() {
         let input = "val = \"Plain\"";
         let expected = str![[r#"
 Val {
@@ -101,7 +104,7 @@ Val {
     }
 
     #[test]
-    fn from_inline_table() {
+    fn value_from_inline_table() {
         let input = "{ Plain = {} }";
         let expected = str![[r#"
 Plain
@@ -109,7 +112,10 @@ Plain
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_inline_table() {
         let input = "val = { Plain = {} }";
         let expected = str![[r#"
 Val {
@@ -162,7 +168,7 @@ mod enum_tuple {
     use super::*;
 
     #[test]
-    fn from_inline_table() {
+    fn value_from_inline_table() {
         let input = "{ Tuple = { 0 = -123, 1 = true } }";
         let expected = str![[r#"
 Tuple(
@@ -173,7 +179,10 @@ Tuple(
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_inline_table() {
         let input = "val = { Tuple = { 0 = -123, 1 = true } }";
         let expected = str![[r#"
 Val {
@@ -210,7 +219,7 @@ mod enum_newtype {
     use super::*;
 
     #[test]
-    fn from_inline_table() {
+    fn value_from_inline_table() {
         let input = r#"{ NewType = "value" }"#;
         let expected = str![[r#"
 NewType(
@@ -220,7 +229,10 @@ NewType(
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_inline_table() {
         let input = r#"val = { NewType = "value" }"#;
         let expected = str![[r#"
 Val {
@@ -266,7 +278,7 @@ mod enum_struct {
     use super::*;
 
     #[test]
-    fn from_inline_table() {
+    fn value_from_inline_table() {
         let input = "{ Struct = { value = -123 } }";
         let expected = str![[r#"
 Struct {
@@ -276,7 +288,10 @@ Struct {
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_inline_table() {
         let input = "val = { Struct = { value = -123 } }";
         let expected = str![[r#"
 Val {

--- a/crates/toml/tests/serde/de_enum.rs
+++ b/crates/toml/tests/serde/de_enum.rs
@@ -76,56 +76,6 @@ unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Str
     assert_data_eq!(result.unwrap_err().to_string(), expected);
 }
 
-#[test]
-fn extra_field_returns_expected_empty_table_error() {
-    let input = "{ Plain = { extra_field = 404 } }";
-    let expected = str![[r#"
-expected empty table
-
-"#]]
-    .raw();
-    let result = crate::value_from_str::<TheEnum>(input);
-    assert_data_eq!(result.unwrap_err().to_string(), expected);
-
-    let input = "val = { Plain = { extra_field = 404 } }";
-    let expected = str![[r#"
-TOML parse error at line 1, column 17
-  |
-1 | val = { Plain = { extra_field = 404 } }
-  |                 ^^^^^^^^^^^^^^^^^^^^^
-expected empty table
-
-"#]]
-    .raw();
-    let result = crate::from_str::<Val>(input);
-    assert_data_eq!(result.unwrap_err().to_string(), expected);
-}
-
-#[test]
-fn extra_field_returns_expected_empty_table_error_struct_variant() {
-    let input = "{ Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }";
-    let expected = str![[r#"
-unexpected keys in table: extra_0, extra_1, available keys: value
-
-"#]]
-    .raw();
-    let result = crate::value_from_str::<TheEnum>(input);
-    assert_data_eq!(result.unwrap_err().to_string(), expected);
-
-    let input = "val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }";
-    let expected = str![[r#"
-TOML parse error at line 1, column 33
-  |
-1 | val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }
-  |                                 ^^^^^^^
-unexpected keys in table: extra_0, extra_1, available keys: value
-
-"#]]
-    .raw();
-    let result = crate::from_str::<Val>(input);
-    assert_data_eq!(result.unwrap_err().to_string(), expected);
-}
-
 mod enum_unit {
     use super::*;
 
@@ -180,6 +130,31 @@ Plain
 "#]];
         let result = crate::from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
+
+    #[test]
+    fn extra_field_returns_expected_empty_table_error() {
+        let input = "{ Plain = { extra_field = 404 } }";
+        let expected = str![[r#"
+expected empty table
+
+"#]]
+        .raw();
+        let result = crate::value_from_str::<TheEnum>(input);
+        assert_data_eq!(result.unwrap_err().to_string(), expected);
+
+        let input = "val = { Plain = { extra_field = 404 } }";
+        let expected = str![[r#"
+TOML parse error at line 1, column 17
+  |
+1 | val = { Plain = { extra_field = 404 } }
+  |                 ^^^^^^^^^^^^^^^^^^^^^
+expected empty table
+
+"#]]
+        .raw();
+        let result = crate::from_str::<Val>(input);
+        assert_data_eq!(result.unwrap_err().to_string(), expected);
     }
 }
 
@@ -337,6 +312,31 @@ OuterStruct {
 "#]];
         let result = crate::from_str::<OuterStruct>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
+
+    #[test]
+    fn extra_field_returns_expected_empty_table_error_struct_variant() {
+        let input = "{ Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }";
+        let expected = str![[r#"
+unexpected keys in table: extra_0, extra_1, available keys: value
+
+"#]]
+        .raw();
+        let result = crate::value_from_str::<TheEnum>(input);
+        assert_data_eq!(result.unwrap_err().to_string(), expected);
+
+        let input = "val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }";
+        let expected = str![[r#"
+TOML parse error at line 1, column 33
+  |
+1 | val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }
+  |                                 ^^^^^^^
+unexpected keys in table: extra_0, extra_1, available keys: value
+
+"#]]
+        .raw();
+        let result = crate::from_str::<Val>(input);
+        assert_data_eq!(result.unwrap_err().to_string(), expected);
     }
 }
 

--- a/crates/toml/tests/serde/de_enum.rs
+++ b/crates/toml/tests/serde/de_enum.rs
@@ -340,7 +340,7 @@ OuterStruct {
     }
 }
 
-mod enum_array {
+mod array_enum {
     use super::*;
 
     #[test]

--- a/crates/toml/tests/serde/general.rs
+++ b/crates/toml/tests/serde/general.rs
@@ -7,15 +7,6 @@ use snapbox::assert_data_eq;
 use snapbox::prelude::*;
 use snapbox::str;
 
-macro_rules! t {
-    ($e:expr) => {
-        match $e {
-            Ok(t) => t,
-            Err(e) => panic!("{} failed with {}", stringify!($e), e),
-        }
-    };
-}
-
 macro_rules! equivalent {
     ($literal:expr, $toml:expr,) => {{
         let toml = $toml;

--- a/crates/toml/tests/serde/main.rs
+++ b/crates/toml/tests/serde/main.rs
@@ -1,6 +1,15 @@
 #![recursion_limit = "256"]
 #![cfg(all(feature = "parse", feature = "display"))]
 
+macro_rules! t {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("{} failed with {}", stringify!($e), e),
+        }
+    };
+}
+
 mod de_enum;
 mod de_errors;
 mod general;

--- a/crates/toml/tests/serde/main.rs
+++ b/crates/toml/tests/serde/main.rs
@@ -4,6 +4,7 @@
 mod de_enum;
 mod de_errors;
 mod general;
+mod ser_enum;
 mod ser_formatting;
 mod ser_formatting_raw;
 mod ser_tables_last;
@@ -26,4 +27,14 @@ where
     T: serde::de::DeserializeOwned,
 {
     T::deserialize(toml::de::ValueDeserializer::new(s))
+}
+
+fn to_string_value<T>(value: &T) -> Result<String, toml::ser::Error>
+where
+    T: serde::ser::Serialize + ?Sized,
+{
+    let mut output = String::new();
+    let serializer = toml::ser::ValueSerializer::new(&mut output);
+    value.serialize(serializer)?;
+    Ok(output)
 }

--- a/crates/toml/tests/serde/ser_enum.rs
+++ b/crates/toml/tests/serde/ser_enum.rs
@@ -198,7 +198,7 @@ mod enum_struct {
     #[test]
     #[should_panic]
     fn to_string_value() {
-        let expected = str!["{ Struct = { value = -123 } }"];
+        let expected = str!["{ value = -123 }"];
         let input = TheEnum::Struct { value: -123 };
         let toml = t!(crate::to_string_value(&input));
         assert_data_eq!(&toml, expected);
@@ -226,7 +226,6 @@ mod enum_struct {
     #[should_panic]
     fn to_string() {
         let expected = str![[r#"
-[Struct]
 value = -123
 
 "#]];

--- a/crates/toml/tests/serde/ser_enum.rs
+++ b/crates/toml/tests/serde/ser_enum.rs
@@ -27,8 +27,8 @@ mod enum_unit {
     fn to_string_value() {
         let expected = str![[r#""Plain""#]];
         let input = TheEnum::Plain;
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -37,8 +37,8 @@ mod enum_unit {
         let input = Val {
             val: TheEnum::Plain,
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -50,8 +50,8 @@ val = "Plain"
         let input = Val {
             val: TheEnum::Plain,
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }
 
@@ -62,8 +62,8 @@ mod enum_tuple {
     fn to_string_value() {
         let expected = str!["[-123, true]"];
         let input = TheEnum::Tuple(-123, true);
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -72,8 +72,8 @@ mod enum_tuple {
         let input = Val {
             val: TheEnum::Tuple(-123, true),
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -89,8 +89,8 @@ Tuple = [
         let input = Val {
             val: TheEnum::Tuple(-123, true),
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }
 
@@ -101,8 +101,8 @@ mod enum_newtype {
     fn to_string_value() {
         let expected = str![[r#"{ NewType = "value" }"#]];
         let input = TheEnum::NewType("value".to_owned());
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -111,8 +111,8 @@ mod enum_newtype {
         let input = Val {
             val: TheEnum::NewType("value".to_owned()),
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -125,8 +125,8 @@ NewType = "value"
         let input = Val {
             val: TheEnum::NewType("value".to_owned()),
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }
 
@@ -138,8 +138,8 @@ mod enum_struct {
     fn to_string_value() {
         let expected = str!["{ Struct = { value = -123 } }"];
         let input = TheEnum::Struct { value: -123 };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -148,8 +148,8 @@ mod enum_struct {
         let input = Val {
             val: TheEnum::Struct { value: -123 },
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -162,8 +162,8 @@ value = -123
         let input = Val {
             val: TheEnum::Struct { value: -123 },
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }
 
@@ -185,8 +185,8 @@ mod array_enum {
                 ]
             },
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -213,7 +213,7 @@ enums = [
                 ]
             },
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }

--- a/crates/toml/tests/serde/ser_enum.rs
+++ b/crates/toml/tests/serde/ser_enum.rs
@@ -97,15 +97,14 @@ mod enum_tuple {
 
     #[test]
     fn to_string_value() {
-        let expected = str!["[-123, true]"];
+        let expected = str!["{ Tuple = [-123, true] }"];
         let input = TheEnum::Tuple(-123, true);
         let toml = t!(crate::to_string_value(&input));
         assert_data_eq!(&toml, expected);
-        // TODO
-        //let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
-        //assert_eq!(roundtrip, input);
-        //let json = json_from_toml_value_str::<TheEnum>(&toml);
-        //assert_eq!(json, input);
+        let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -196,9 +195,8 @@ mod enum_struct {
     use super::*;
 
     #[test]
-    #[should_panic]
     fn to_string_value() {
-        let expected = str!["{ value = -123 }"];
+        let expected = str!["{ Struct = { value = -123 } }"];
         let input = TheEnum::Struct { value: -123 };
         let toml = t!(crate::to_string_value(&input));
         assert_data_eq!(&toml, expected);
@@ -223,9 +221,9 @@ mod enum_struct {
     }
 
     #[test]
-    #[should_panic]
     fn to_string() {
         let expected = str![[r#"
+[Struct]
 value = -123
 
 "#]];

--- a/crates/toml/tests/serde/ser_enum.rs
+++ b/crates/toml/tests/serde/ser_enum.rs
@@ -75,7 +75,7 @@ mod enum_unit {
     }
 
     #[test]
-    fn to_string() {
+    fn nested_to_string() {
         let expected = str![[r#"
 val = "Plain"
 
@@ -123,7 +123,7 @@ mod enum_tuple {
     }
 
     #[test]
-    fn to_string() {
+    fn nested_to_string() {
         let expected = str![[r#"
 [val]
 Tuple = [
@@ -174,7 +174,7 @@ mod enum_newtype {
     }
 
     #[test]
-    fn to_string() {
+    fn nested_to_string() {
         let expected = str![[r#"
 [val]
 NewType = "value"
@@ -223,7 +223,24 @@ mod enum_struct {
     }
 
     #[test]
+    #[should_panic]
     fn to_string() {
+        let expected = str![[r#"
+[Struct]
+value = -123
+
+"#]];
+        let input = TheEnum::Struct { value: -123 };
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
+    }
+
+    #[test]
+    fn nested_to_string() {
         let expected = str![[r#"
 [val.Struct]
 value = -123

--- a/crates/toml/tests/serde/ser_enum.rs
+++ b/crates/toml/tests/serde/ser_enum.rs
@@ -21,6 +21,30 @@ struct Multi {
     enums: Vec<TheEnum>,
 }
 
+/// Verify that `ser` produces values compatible with `serde_json`
+#[track_caller]
+fn json_from_toml_value_str<T>(s: &'_ str) -> T
+where
+    T: serde::de::DeserializeOwned,
+{
+    let value = t!(crate::value_from_str::<crate::SerdeValue>(s));
+    let value = t!(value.try_into::<serde_json::Value>());
+    let json = t!(serde_json::to_string_pretty(&value));
+    t!(serde_json::from_str::<T>(&json))
+}
+
+/// Verify that `ser` produces documents compatible with `serde_json`
+#[track_caller]
+fn json_from_toml_str<T>(s: &'_ str) -> T
+where
+    T: serde::de::DeserializeOwned,
+{
+    let value = t!(crate::from_str::<crate::SerdeTable>(s));
+    let value = t!(value.try_into::<serde_json::Value>());
+    let json = t!(serde_json::to_string_pretty(&value));
+    t!(serde_json::from_str::<T>(&json))
+}
+
 mod enum_unit {
     use super::*;
 
@@ -32,6 +56,8 @@ mod enum_unit {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -44,6 +70,8 @@ mod enum_unit {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -59,6 +87,8 @@ val = "Plain"
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 }
 
@@ -74,6 +104,8 @@ mod enum_tuple {
         // TODO
         //let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
         //assert_eq!(roundtrip, input);
+        //let json = json_from_toml_value_str::<TheEnum>(&toml);
+        //assert_eq!(json, input);
     }
 
     #[test]
@@ -86,6 +118,8 @@ mod enum_tuple {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -105,6 +139,8 @@ Tuple = [
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 }
 
@@ -119,6 +155,8 @@ mod enum_newtype {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -131,6 +169,8 @@ mod enum_newtype {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -147,6 +187,8 @@ NewType = "value"
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 }
 
@@ -162,6 +204,8 @@ mod enum_struct {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -174,6 +218,8 @@ mod enum_struct {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -190,6 +236,8 @@ value = -123
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 }
 
@@ -215,6 +263,8 @@ mod array_enum {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Multi>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Multi>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -245,5 +295,7 @@ enums = [
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Multi>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Multi>(&toml);
+        assert_eq!(json, input);
     }
 }

--- a/crates/toml/tests/serde/ser_enum.rs
+++ b/crates/toml/tests/serde/ser_enum.rs
@@ -1,0 +1,219 @@
+use serde::Serialize;
+use snapbox::assert_data_eq;
+use snapbox::str;
+
+#[derive(Debug, Serialize, PartialEq)]
+enum TheEnum {
+    Plain,
+    Tuple(i64, bool),
+    NewType(String),
+    Struct { value: i64 },
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct Val {
+    val: TheEnum,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct Multi {
+    enums: Vec<TheEnum>,
+}
+
+mod enum_unit {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str![[r#""Plain""#]];
+        let input = TheEnum::Plain;
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn nested_to_string_value() {
+        let expected = str![[r#"{ val = "Plain" }"#]];
+        let input = Val {
+            val: TheEnum::Plain,
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+val = "Plain"
+
+"#]];
+        let input = Val {
+            val: TheEnum::Plain,
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}
+
+mod enum_tuple {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str!["[-123, true]"];
+        let input = TheEnum::Tuple(-123, true);
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn nested_to_string_value() {
+        let expected = str!["{ val = { Tuple = [-123, true] } }"];
+        let input = Val {
+            val: TheEnum::Tuple(-123, true),
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+[val]
+Tuple = [
+    -123,
+    true,
+]
+
+"#]];
+        let input = Val {
+            val: TheEnum::Tuple(-123, true),
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}
+
+mod enum_newtype {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str![[r#"{ NewType = "value" }"#]];
+        let input = TheEnum::NewType("value".to_owned());
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn nested_to_string_value() {
+        let expected = str![[r#"{ val = { NewType = "value" } }"#]];
+        let input = Val {
+            val: TheEnum::NewType("value".to_owned()),
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+[val]
+NewType = "value"
+
+"#]];
+        let input = Val {
+            val: TheEnum::NewType("value".to_owned()),
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}
+
+mod enum_struct {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn to_string_value() {
+        let expected = str!["{ Struct = { value = -123 } }"];
+        let input = TheEnum::Struct { value: -123 };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn nested_to_string_value() {
+        let expected = str!["{ val = { Struct = { value = -123 } } }"];
+        let input = Val {
+            val: TheEnum::Struct { value: -123 },
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+[val.Struct]
+value = -123
+
+"#]];
+        let input = Val {
+            val: TheEnum::Struct { value: -123 },
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}
+
+mod array_enum {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str![[
+            r#"{ enums = ["Plain", { Tuple = [-123, true] }, { NewType = "value" }, { Struct = { value = -123 } }] }"#
+        ]];
+        let input = Multi {
+            enums: {
+                vec![
+                    TheEnum::Plain,
+                    TheEnum::Tuple(-123, true),
+                    TheEnum::NewType("value".to_owned()),
+                    TheEnum::Struct { value: -123 },
+                ]
+            },
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+enums = [
+    "Plain",
+    { Tuple = [
+    -123,
+    true,
+] },
+    { NewType = "value" },
+    { Struct = { value = -123 } },
+]
+
+"#]];
+        let input = Multi {
+            enums: {
+                vec![
+                    TheEnum::Plain,
+                    TheEnum::Tuple(-123, true),
+                    TheEnum::NewType("value".to_owned()),
+                    TheEnum::Struct { value: -123 },
+                ]
+            },
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}

--- a/crates/toml/tests/serde/ser_enum.rs
+++ b/crates/toml/tests/serde/ser_enum.rs
@@ -1,8 +1,9 @@
+use serde::Deserialize;
 use serde::Serialize;
 use snapbox::assert_data_eq;
 use snapbox::str;
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 enum TheEnum {
     Plain,
     Tuple(i64, bool),
@@ -10,12 +11,12 @@ enum TheEnum {
     Struct { value: i64 },
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 struct Val {
     val: TheEnum,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 struct Multi {
     enums: Vec<TheEnum>,
 }
@@ -28,7 +29,9 @@ mod enum_unit {
         let expected = str![[r#""Plain""#]];
         let input = TheEnum::Plain;
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -38,7 +41,9 @@ mod enum_unit {
             val: TheEnum::Plain,
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -51,7 +56,9 @@ val = "Plain"
             val: TheEnum::Plain,
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }
 
@@ -63,7 +70,10 @@ mod enum_tuple {
         let expected = str!["[-123, true]"];
         let input = TheEnum::Tuple(-123, true);
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        // TODO
+        //let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        //assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -73,7 +83,9 @@ mod enum_tuple {
             val: TheEnum::Tuple(-123, true),
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -90,7 +102,9 @@ Tuple = [
             val: TheEnum::Tuple(-123, true),
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }
 
@@ -102,7 +116,9 @@ mod enum_newtype {
         let expected = str![[r#"{ NewType = "value" }"#]];
         let input = TheEnum::NewType("value".to_owned());
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -112,7 +128,9 @@ mod enum_newtype {
             val: TheEnum::NewType("value".to_owned()),
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -126,7 +144,9 @@ NewType = "value"
             val: TheEnum::NewType("value".to_owned()),
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }
 
@@ -139,7 +159,9 @@ mod enum_struct {
         let expected = str!["{ Struct = { value = -123 } }"];
         let input = TheEnum::Struct { value: -123 };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -149,7 +171,9 @@ mod enum_struct {
             val: TheEnum::Struct { value: -123 },
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -163,7 +187,9 @@ value = -123
             val: TheEnum::Struct { value: -123 },
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }
 
@@ -186,7 +212,9 @@ mod array_enum {
             },
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Multi>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -214,6 +242,8 @@ enums = [
             },
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Multi>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }

--- a/crates/toml_edit/src/ser/array.rs
+++ b/crates/toml_edit/src/ser/array.rs
@@ -49,22 +49,6 @@ impl serde::ser::SerializeTuple for SerializeValueArray {
     }
 }
 
-impl serde::ser::SerializeTupleVariant for SerializeValueArray {
-    type Ok = crate::Value;
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
-    where
-        T: serde::ser::Serialize + ?Sized,
-    {
-        serde::ser::SerializeSeq::serialize_element(self, value)
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        serde::ser::SerializeSeq::end(self)
-    }
-}
-
 impl serde::ser::SerializeTupleStruct for SerializeValueArray {
     type Ok = crate::Value;
     type Error = Error;

--- a/crates/toml_edit/src/ser/mod.rs
+++ b/crates/toml_edit/src/ser/mod.rs
@@ -83,7 +83,7 @@ where
     T: serde::ser::Serialize + ?Sized,
 {
     let mut document = to_document(value)?;
-    pretty::Pretty.visit_document_mut(&mut document);
+    pretty::Pretty::new().visit_document_mut(&mut document);
     Ok(document.to_string())
 }
 

--- a/crates/toml_edit/src/ser/pretty.rs
+++ b/crates/toml_edit/src/ser/pretty.rs
@@ -1,4 +1,12 @@
-pub(crate) struct Pretty;
+pub(crate) struct Pretty {
+    in_value: bool,
+}
+
+impl Pretty {
+    pub(crate) fn new() -> Self {
+        Self { in_value: false }
+    }
+}
 
 impl crate::visit_mut::VisitMut for Pretty {
     fn visit_document_mut(&mut self, node: &mut crate::DocumentMut) {
@@ -6,7 +14,9 @@ impl crate::visit_mut::VisitMut for Pretty {
     }
 
     fn visit_item_mut(&mut self, node: &mut crate::Item) {
-        node.make_item();
+        if !self.in_value {
+            node.make_item();
+        }
 
         crate::visit_mut::visit_item_mut(self, node);
     }
@@ -25,7 +35,10 @@ impl crate::visit_mut::VisitMut for Pretty {
     fn visit_value_mut(&mut self, node: &mut crate::Value) {
         node.decor_mut().clear();
 
+        let old_in_value = self.in_value;
+        self.in_value = true;
         crate::visit_mut::visit_value_mut(self, node);
+        self.in_value = old_in_value;
     }
 
     fn visit_array_mut(&mut self, node: &mut crate::Array) {

--- a/crates/toml_edit/tests/serde/de_enum.rs
+++ b/crates/toml_edit/tests/serde/de_enum.rs
@@ -236,21 +236,29 @@ Val {
 
     #[test]
     fn from_std_table() {
-        assert_eq!(
-            TheEnum::NewType("value".to_owned()),
-            crate::from_str(r#"NewType = "value""#).unwrap()
-        );
-        assert_eq!(
-            Val {
-                val: TheEnum::NewType("value".to_owned()),
-            },
-            crate::from_str(
-                r#"[val]
+        let result = crate::from_str::<TheEnum>(r#"NewType = "value""#);
+        let expected = str![[r#"
+NewType(
+    "value",
+)
+
+"#]];
+        assert_data_eq!(result.unwrap().to_debug(), expected);
+
+        let result = crate::from_str::<Val>(
+            r#"[val]
                 NewType = "value"
-                "#
-            )
-            .unwrap()
+                "#,
         );
+        let expected = str![[r#"
+Val {
+    val: NewType(
+        "value",
+    ),
+}
+
+"#]];
+        assert_data_eq!(result.unwrap().to_debug(), expected);
     }
 }
 

--- a/crates/toml_edit/tests/serde/de_enum.rs
+++ b/crates/toml_edit/tests/serde/de_enum.rs
@@ -80,7 +80,7 @@ mod enum_unit {
     use super::*;
 
     #[test]
-    fn from_str() {
+    fn value_from_str() {
         let input = "\"Plain\"";
         let expected = str![[r#"
 Plain
@@ -88,7 +88,10 @@ Plain
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_str() {
         let input = "val = \"Plain\"";
         let expected = str![[r#"
 Val {
@@ -101,7 +104,7 @@ Val {
     }
 
     #[test]
-    fn from_inline_table() {
+    fn value_from_inline_table() {
         let input = "{ Plain = {} }";
         let expected = str![[r#"
 Plain
@@ -109,7 +112,10 @@ Plain
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_inline_table() {
         let input = "val = { Plain = {} }";
         let expected = str![[r#"
 Val {
@@ -162,7 +168,7 @@ mod enum_tuple {
     use super::*;
 
     #[test]
-    fn from_inline_table() {
+    fn value_from_inline_table() {
         let input = "{ Tuple = { 0 = -123, 1 = true } }";
         let expected = str![[r#"
 Tuple(
@@ -173,7 +179,10 @@ Tuple(
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_inline_table() {
         let input = "val = { Tuple = { 0 = -123, 1 = true } }";
         let expected = str![[r#"
 Val {
@@ -210,7 +219,7 @@ mod enum_newtype {
     use super::*;
 
     #[test]
-    fn from_inline_table() {
+    fn value_from_inline_table() {
         let input = r#"{ NewType = "value" }"#;
         let expected = str![[r#"
 NewType(
@@ -220,7 +229,10 @@ NewType(
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_inline_table() {
         let input = r#"val = { NewType = "value" }"#;
         let expected = str![[r#"
 Val {
@@ -266,7 +278,7 @@ mod enum_struct {
     use super::*;
 
     #[test]
-    fn from_inline_table() {
+    fn value_from_inline_table() {
         let input = "{ Struct = { value = -123 } }";
         let expected = str![[r#"
 Struct {
@@ -276,7 +288,10 @@ Struct {
 "#]];
         let result = crate::value_from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
 
+    #[test]
+    fn from_inline_table() {
         let input = "val = { Struct = { value = -123 } }";
         let expected = str![[r#"
 Val {

--- a/crates/toml_edit/tests/serde/de_enum.rs
+++ b/crates/toml_edit/tests/serde/de_enum.rs
@@ -76,56 +76,6 @@ unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Str
     assert_data_eq!(result.unwrap_err().to_string(), expected);
 }
 
-#[test]
-fn extra_field_returns_expected_empty_table_error() {
-    let input = "{ Plain = { extra_field = 404 } }";
-    let expected = str![[r#"
-expected empty table
-
-"#]]
-    .raw();
-    let result = crate::value_from_str::<TheEnum>(input);
-    assert_data_eq!(result.unwrap_err().to_string(), expected);
-
-    let input = "val = { Plain = { extra_field = 404 } }";
-    let expected = str![[r#"
-TOML parse error at line 1, column 17
-  |
-1 | val = { Plain = { extra_field = 404 } }
-  |                 ^^^^^^^^^^^^^^^^^^^^^
-expected empty table
-
-"#]]
-    .raw();
-    let result = crate::from_str::<Val>(input);
-    assert_data_eq!(result.unwrap_err().to_string(), expected);
-}
-
-#[test]
-fn extra_field_returns_expected_empty_table_error_struct_variant() {
-    let input = "{ Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }";
-    let expected = str![[r#"
-unexpected keys in table: extra_0, extra_1, available keys: value
-
-"#]]
-    .raw();
-    let result = crate::value_from_str::<TheEnum>(input);
-    assert_data_eq!(result.unwrap_err().to_string(), expected);
-
-    let input = "val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }";
-    let expected = str![[r#"
-TOML parse error at line 1, column 33
-  |
-1 | val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }
-  |                                 ^^^^^^^
-unexpected keys in table: extra_0, extra_1, available keys: value
-
-"#]]
-    .raw();
-    let result = crate::from_str::<Val>(input);
-    assert_data_eq!(result.unwrap_err().to_string(), expected);
-}
-
 mod enum_unit {
     use super::*;
 
@@ -180,6 +130,31 @@ Plain
 "#]];
         let result = crate::from_str::<TheEnum>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
+
+    #[test]
+    fn extra_field_returns_expected_empty_table_error() {
+        let input = "{ Plain = { extra_field = 404 } }";
+        let expected = str![[r#"
+expected empty table
+
+"#]]
+        .raw();
+        let result = crate::value_from_str::<TheEnum>(input);
+        assert_data_eq!(result.unwrap_err().to_string(), expected);
+
+        let input = "val = { Plain = { extra_field = 404 } }";
+        let expected = str![[r#"
+TOML parse error at line 1, column 17
+  |
+1 | val = { Plain = { extra_field = 404 } }
+  |                 ^^^^^^^^^^^^^^^^^^^^^
+expected empty table
+
+"#]]
+        .raw();
+        let result = crate::from_str::<Val>(input);
+        assert_data_eq!(result.unwrap_err().to_string(), expected);
     }
 }
 
@@ -337,6 +312,31 @@ OuterStruct {
 "#]];
         let result = crate::from_str::<OuterStruct>(input);
         assert_data_eq!(result.unwrap().to_debug(), expected);
+    }
+
+    #[test]
+    fn extra_field_returns_expected_empty_table_error_struct_variant() {
+        let input = "{ Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }";
+        let expected = str![[r#"
+unexpected keys in table: extra_0, extra_1, available keys: value
+
+"#]]
+        .raw();
+        let result = crate::value_from_str::<TheEnum>(input);
+        assert_data_eq!(result.unwrap_err().to_string(), expected);
+
+        let input = "val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }";
+        let expected = str![[r#"
+TOML parse error at line 1, column 33
+  |
+1 | val = { Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }
+  |                                 ^^^^^^^
+unexpected keys in table: extra_0, extra_1, available keys: value
+
+"#]]
+        .raw();
+        let result = crate::from_str::<Val>(input);
+        assert_data_eq!(result.unwrap_err().to_string(), expected);
     }
 }
 

--- a/crates/toml_edit/tests/serde/de_enum.rs
+++ b/crates/toml_edit/tests/serde/de_enum.rs
@@ -340,7 +340,7 @@ OuterStruct {
     }
 }
 
-mod enum_array {
+mod array_enum {
     use super::*;
 
     #[test]

--- a/crates/toml_edit/tests/serde/general.rs
+++ b/crates/toml_edit/tests/serde/general.rs
@@ -7,15 +7,6 @@ use snapbox::assert_data_eq;
 use snapbox::prelude::*;
 use snapbox::str;
 
-macro_rules! t {
-    ($e:expr) => {
-        match $e {
-            Ok(t) => t,
-            Err(e) => panic!("{} failed with {}", stringify!($e), e),
-        }
-    };
-}
-
 macro_rules! equivalent {
     ($literal:expr, $toml:expr,) => {{
         let toml = $toml;

--- a/crates/toml_edit/tests/serde/main.rs
+++ b/crates/toml_edit/tests/serde/main.rs
@@ -1,6 +1,15 @@
 #![recursion_limit = "256"]
 #![cfg(all(feature = "parse", feature = "display"))]
 
+macro_rules! t {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("{} failed with {}", stringify!($e), e),
+        }
+    };
+}
+
 mod de_enum;
 mod de_errors;
 mod general;

--- a/crates/toml_edit/tests/serde/main.rs
+++ b/crates/toml_edit/tests/serde/main.rs
@@ -4,6 +4,7 @@
 mod de_enum;
 mod de_errors;
 mod general;
+mod ser_enum;
 mod ser_formatting;
 mod ser_formatting_raw;
 mod ser_tables_last;
@@ -26,4 +27,14 @@ where
     T: serde::de::DeserializeOwned,
 {
     T::deserialize(s.parse::<toml_edit::de::ValueDeserializer>().unwrap())
+}
+
+fn to_string_value<T>(value: &T) -> Result<String, toml_edit::ser::Error>
+where
+    T: serde::ser::Serialize + ?Sized,
+{
+    let serializer = toml_edit::ser::ValueSerializer::new();
+    let value = value.serialize(serializer)?;
+    let output = value.to_string();
+    Ok(output)
 }

--- a/crates/toml_edit/tests/serde/ser_enum.rs
+++ b/crates/toml_edit/tests/serde/ser_enum.rs
@@ -1,0 +1,218 @@
+use serde::Serialize;
+use snapbox::assert_data_eq;
+use snapbox::str;
+
+#[derive(Debug, Serialize, PartialEq)]
+enum TheEnum {
+    Plain,
+    Tuple(i64, bool),
+    NewType(String),
+    Struct { value: i64 },
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct Val {
+    val: TheEnum,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct Multi {
+    enums: Vec<TheEnum>,
+}
+
+mod enum_unit {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str![[r#""Plain""#]];
+        let input = TheEnum::Plain;
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn nested_to_string_value() {
+        let expected = str![[r#"{ val = "Plain" }"#]];
+        let input = Val {
+            val: TheEnum::Plain,
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+val = "Plain"
+
+"#]];
+        let input = Val {
+            val: TheEnum::Plain,
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}
+
+mod enum_tuple {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str!["{ Tuple = [-123, true] }"];
+        let input = TheEnum::Tuple(-123, true);
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn nested_to_string_value() {
+        let expected = str!["{ val = { Tuple = [-123, true] } }"];
+        let input = Val {
+            val: TheEnum::Tuple(-123, true),
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+[val]
+Tuple = [
+    -123,
+    true,
+]
+
+"#]];
+        let input = Val {
+            val: TheEnum::Tuple(-123, true),
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}
+
+mod enum_newtype {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str![[r#"{ NewType = "value" }"#]];
+        let input = TheEnum::NewType("value".to_owned());
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn nested_to_string_value() {
+        let expected = str![[r#"{ val = { NewType = "value" } }"#]];
+        let input = Val {
+            val: TheEnum::NewType("value".to_owned()),
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+[val]
+NewType = "value"
+
+"#]];
+        let input = Val {
+            val: TheEnum::NewType("value".to_owned()),
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}
+
+mod enum_struct {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str!["{ Struct = { value = -123 } }"];
+        let input = TheEnum::Struct { value: -123 };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn nested_to_string_value() {
+        let expected = str!["{ val = { Struct = { value = -123 } } }"];
+        let input = Val {
+            val: TheEnum::Struct { value: -123 },
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+[val.Struct]
+value = -123
+
+"#]];
+        let input = Val {
+            val: TheEnum::Struct { value: -123 },
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}
+
+mod array_enum {
+    use super::*;
+
+    #[test]
+    fn to_string_value() {
+        let expected = str![[
+            r#"{ enums = ["Plain", { Tuple = [-123, true] }, { NewType = "value" }, { Struct = { value = -123 } }] }"#
+        ]];
+        let input = Multi {
+            enums: {
+                vec![
+                    TheEnum::Plain,
+                    TheEnum::Tuple(-123, true),
+                    TheEnum::NewType("value".to_owned()),
+                    TheEnum::Struct { value: -123 },
+                ]
+            },
+        };
+        let result = crate::to_string_value(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn to_string() {
+        let expected = str![[r#"
+enums = [
+    "Plain",
+    { Tuple = [
+    -123,
+    true,
+] },
+    { NewType = "value" },
+    {},
+]
+
+"#]];
+        let input = Multi {
+            enums: {
+                vec![
+                    TheEnum::Plain,
+                    TheEnum::Tuple(-123, true),
+                    TheEnum::NewType("value".to_owned()),
+                    TheEnum::Struct { value: -123 },
+                ]
+            },
+        };
+        let result = crate::to_string_pretty(&input);
+        assert_data_eq!(result.unwrap(), expected);
+    }
+}

--- a/crates/toml_edit/tests/serde/ser_enum.rs
+++ b/crates/toml_edit/tests/serde/ser_enum.rs
@@ -1,8 +1,9 @@
+use serde::Deserialize;
 use serde::Serialize;
 use snapbox::assert_data_eq;
 use snapbox::str;
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 enum TheEnum {
     Plain,
     Tuple(i64, bool),
@@ -10,12 +11,12 @@ enum TheEnum {
     Struct { value: i64 },
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 struct Val {
     val: TheEnum,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 struct Multi {
     enums: Vec<TheEnum>,
 }
@@ -28,7 +29,9 @@ mod enum_unit {
         let expected = str![[r#""Plain""#]];
         let input = TheEnum::Plain;
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -38,7 +41,9 @@ mod enum_unit {
             val: TheEnum::Plain,
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -51,7 +56,9 @@ val = "Plain"
             val: TheEnum::Plain,
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }
 
@@ -63,7 +70,10 @@ mod enum_tuple {
         let expected = str!["{ Tuple = [-123, true] }"];
         let input = TheEnum::Tuple(-123, true);
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        // TODO
+        //let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        //assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -73,7 +83,9 @@ mod enum_tuple {
             val: TheEnum::Tuple(-123, true),
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -90,7 +102,9 @@ Tuple = [
             val: TheEnum::Tuple(-123, true),
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }
 
@@ -102,7 +116,9 @@ mod enum_newtype {
         let expected = str![[r#"{ NewType = "value" }"#]];
         let input = TheEnum::NewType("value".to_owned());
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -112,7 +128,9 @@ mod enum_newtype {
             val: TheEnum::NewType("value".to_owned()),
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -126,7 +144,9 @@ NewType = "value"
             val: TheEnum::NewType("value".to_owned()),
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }
 
@@ -138,7 +158,9 @@ mod enum_struct {
         let expected = str!["{ Struct = { value = -123 } }"];
         let input = TheEnum::Struct { value: -123 };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -148,7 +170,9 @@ mod enum_struct {
             val: TheEnum::Struct { value: -123 },
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -162,7 +186,9 @@ value = -123
             val: TheEnum::Struct { value: -123 },
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<Val>(&toml));
+        assert_eq!(roundtrip, input);
     }
 }
 
@@ -185,7 +211,9 @@ mod array_enum {
             },
         };
         let toml = t!(crate::to_string_value(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::value_from_str::<Multi>(&toml));
+        assert_eq!(roundtrip, input);
     }
 
     #[test]
@@ -213,6 +241,8 @@ enums = [
             },
         };
         let toml = t!(crate::to_string_pretty(&input));
-        assert_data_eq!(toml, expected);
+        assert_data_eq!(&toml, expected);
+        //let roundtrip = t!(crate::from_str::<Multi>(&toml));
+        //assert_eq!(roundtrip, input);
     }
 }

--- a/crates/toml_edit/tests/serde/ser_enum.rs
+++ b/crates/toml_edit/tests/serde/ser_enum.rs
@@ -27,8 +27,8 @@ mod enum_unit {
     fn to_string_value() {
         let expected = str![[r#""Plain""#]];
         let input = TheEnum::Plain;
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -37,8 +37,8 @@ mod enum_unit {
         let input = Val {
             val: TheEnum::Plain,
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -50,8 +50,8 @@ val = "Plain"
         let input = Val {
             val: TheEnum::Plain,
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }
 
@@ -62,8 +62,8 @@ mod enum_tuple {
     fn to_string_value() {
         let expected = str!["{ Tuple = [-123, true] }"];
         let input = TheEnum::Tuple(-123, true);
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -72,8 +72,8 @@ mod enum_tuple {
         let input = Val {
             val: TheEnum::Tuple(-123, true),
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -89,8 +89,8 @@ Tuple = [
         let input = Val {
             val: TheEnum::Tuple(-123, true),
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }
 
@@ -101,8 +101,8 @@ mod enum_newtype {
     fn to_string_value() {
         let expected = str![[r#"{ NewType = "value" }"#]];
         let input = TheEnum::NewType("value".to_owned());
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -111,8 +111,8 @@ mod enum_newtype {
         let input = Val {
             val: TheEnum::NewType("value".to_owned()),
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -125,8 +125,8 @@ NewType = "value"
         let input = Val {
             val: TheEnum::NewType("value".to_owned()),
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }
 
@@ -137,8 +137,8 @@ mod enum_struct {
     fn to_string_value() {
         let expected = str!["{ Struct = { value = -123 } }"];
         let input = TheEnum::Struct { value: -123 };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -147,8 +147,8 @@ mod enum_struct {
         let input = Val {
             val: TheEnum::Struct { value: -123 },
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -161,8 +161,8 @@ value = -123
         let input = Val {
             val: TheEnum::Struct { value: -123 },
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }
 
@@ -184,8 +184,8 @@ mod array_enum {
                 ]
             },
         };
-        let result = crate::to_string_value(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_value(&input));
+        assert_data_eq!(toml, expected);
     }
 
     #[test]
@@ -212,7 +212,7 @@ enums = [
                 ]
             },
         };
-        let result = crate::to_string_pretty(&input);
-        assert_data_eq!(result.unwrap(), expected);
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(toml, expected);
     }
 }

--- a/crates/toml_edit/tests/serde/ser_enum.rs
+++ b/crates/toml_edit/tests/serde/ser_enum.rs
@@ -21,6 +21,30 @@ struct Multi {
     enums: Vec<TheEnum>,
 }
 
+/// Verify that `ser` produces values compatible with `serde_json`
+#[track_caller]
+fn json_from_toml_value_str<T>(s: &'_ str) -> T
+where
+    T: serde::de::DeserializeOwned,
+{
+    let value = t!(crate::value_from_str::<crate::SerdeValue>(s));
+    let value = t!(value.try_into::<serde_json::Value>());
+    let json = t!(serde_json::to_string_pretty(&value));
+    t!(serde_json::from_str::<T>(&json))
+}
+
+/// Verify that `ser` produces documents compatible with `serde_json`
+#[track_caller]
+fn json_from_toml_str<T>(s: &'_ str) -> T
+where
+    T: serde::de::DeserializeOwned,
+{
+    let value = t!(crate::from_str::<crate::SerdeTable>(s));
+    let value = t!(value.try_into::<serde_json::Value>());
+    let json = t!(serde_json::to_string_pretty(&value));
+    t!(serde_json::from_str::<T>(&json))
+}
+
 mod enum_unit {
     use super::*;
 
@@ -32,6 +56,8 @@ mod enum_unit {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -44,6 +70,8 @@ mod enum_unit {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -59,6 +87,8 @@ val = "Plain"
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 }
 
@@ -71,9 +101,10 @@ mod enum_tuple {
         let input = TheEnum::Tuple(-123, true);
         let toml = t!(crate::to_string_value(&input));
         assert_data_eq!(&toml, expected);
-        // TODO
-        //let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
-        //assert_eq!(roundtrip, input);
+        let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -86,6 +117,8 @@ mod enum_tuple {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -105,6 +138,8 @@ Tuple = [
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 }
 
@@ -119,6 +154,8 @@ mod enum_newtype {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -131,6 +168,8 @@ mod enum_newtype {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -147,6 +186,8 @@ NewType = "value"
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 }
 
@@ -161,6 +202,8 @@ mod enum_struct {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<TheEnum>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -173,6 +216,8 @@ mod enum_struct {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -189,6 +234,8 @@ value = -123
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::from_str::<Val>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Val>(&toml);
+        assert_eq!(json, input);
     }
 }
 
@@ -214,6 +261,8 @@ mod array_enum {
         assert_data_eq!(&toml, expected);
         let roundtrip = t!(crate::value_from_str::<Multi>(&toml));
         assert_eq!(roundtrip, input);
+        let json = json_from_toml_value_str::<Multi>(&toml);
+        assert_eq!(json, input);
     }
 
     #[test]
@@ -242,7 +291,10 @@ enums = [
         };
         let toml = t!(crate::to_string_pretty(&input));
         assert_data_eq!(&toml, expected);
+        // TODO
         //let roundtrip = t!(crate::from_str::<Multi>(&toml));
         //assert_eq!(roundtrip, input);
+        //let json = json_from_toml_str::<Multi>(&toml);
+        //assert_eq!(json, input);
     }
 }

--- a/crates/toml_edit/tests/serde/ser_enum.rs
+++ b/crates/toml_edit/tests/serde/ser_enum.rs
@@ -275,7 +275,7 @@ enums = [
     true,
 ] },
     { NewType = "value" },
-    {},
+    { Struct = { value = -123 } },
 ]
 
 "#]];
@@ -291,10 +291,9 @@ enums = [
         };
         let toml = t!(crate::to_string_pretty(&input));
         assert_data_eq!(&toml, expected);
-        // TODO
-        //let roundtrip = t!(crate::from_str::<Multi>(&toml));
-        //assert_eq!(roundtrip, input);
-        //let json = json_from_toml_str::<Multi>(&toml);
-        //assert_eq!(json, input);
+        let roundtrip = t!(crate::from_str::<Multi>(&toml));
+        assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<Multi>(&toml);
+        assert_eq!(json, input);
     }
 }

--- a/crates/toml_edit/tests/serde/ser_enum.rs
+++ b/crates/toml_edit/tests/serde/ser_enum.rs
@@ -75,7 +75,7 @@ mod enum_unit {
     }
 
     #[test]
-    fn to_string() {
+    fn nested_to_string() {
         let expected = str![[r#"
 val = "Plain"
 
@@ -122,7 +122,7 @@ mod enum_tuple {
     }
 
     #[test]
-    fn to_string() {
+    fn nested_to_string() {
         let expected = str![[r#"
 [val]
 Tuple = [
@@ -173,7 +173,7 @@ mod enum_newtype {
     }
 
     #[test]
-    fn to_string() {
+    fn nested_to_string() {
         let expected = str![[r#"
 [val]
 NewType = "value"
@@ -222,6 +222,22 @@ mod enum_struct {
 
     #[test]
     fn to_string() {
+        let expected = str![[r#"
+[Struct]
+value = -123
+
+"#]];
+        let input = TheEnum::Struct { value: -123 };
+        let toml = t!(crate::to_string_pretty(&input));
+        assert_data_eq!(&toml, expected);
+        let roundtrip = t!(crate::from_str::<TheEnum>(&toml));
+        assert_eq!(roundtrip, input);
+        let json = json_from_toml_str::<TheEnum>(&toml);
+        assert_eq!(json, input);
+    }
+
+    #[test]
+    fn nested_to_string() {
         let expected = str![[r#"
 [val.Struct]
 value = -123


### PR DESCRIPTION
- In `toml_edit`, nested tables weren't being serialized correctly
- In `toml`, struct and tuple variants weren't being serialized correctly

Technically, we've changed
- `Serializer` associated types except we generally consider these to be implementation details
- The output on a successful serialization of tuple variants with `ValueSerializer`.  However, this was only in certain cases and wasn't deserializable

Fixes #880