### PR TITLE
feat(parse): Add whitespace validation helper

### DIFF
--- a/crates/benchmarks/benches/0-cargo.rs
+++ b/crates/benchmarks/benches/0-cargo.rs
@@ -30,40 +30,6 @@ mod toml_parse {
         }
 
         impl ::toml_parse::parser::EventReceiver for Void<'_> {
-            fn comment(
-                &mut self,
-                span: ::toml_parse::Span,
-                error: &mut dyn ::toml_parse::ErrorSink,
-            ) {
-                let event = ::toml_parse::parser::Event::new_unchecked(
-                    ::toml_parse::parser::EventKind::Comment,
-                    None,
-                    span,
-                );
-                #[cfg(feature = "unsafe")] // SAFETY: `EventReceiver` should always receive valid
-                // spans
-                let raw = unsafe { self.source.get_unchecked(event) };
-                #[cfg(not(feature = "unsafe"))]
-                let raw = self.source.get(event).unwrap();
-                raw.decode_comment(error);
-            }
-            fn newline(
-                &mut self,
-                span: ::toml_parse::Span,
-                error: &mut dyn ::toml_parse::ErrorSink,
-            ) {
-                let event = ::toml_parse::parser::Event::new_unchecked(
-                    ::toml_parse::parser::EventKind::Comment,
-                    None,
-                    span,
-                );
-                #[cfg(feature = "unsafe")] // SAFETY: `EventReceiver` should always receive valid
-                // spans
-                let raw = unsafe { self.source.get_unchecked(event) };
-                #[cfg(not(feature = "unsafe"))]
-                let raw = self.source.get(event).unwrap();
-                raw.decode_newline(error);
-            }
             fn simple_key(
                 &mut self,
                 span: ::toml_parse::Span,
@@ -109,7 +75,8 @@ mod toml_parse {
         let tokens = source.lex().into_vec();
         let mut errors = Vec::new();
         let mut events = Void { source: &source };
-        ::toml_parse::parser::parse_document(&tokens, &mut events, &mut errors);
+        let mut receiver = toml_parse::parser::ValidateWhitespace::new(&mut events, source);
+        ::toml_parse::parser::parse_document(&tokens, &mut receiver, &mut errors);
     }
 }
 

--- a/crates/benchmarks/benches/1-map.rs
+++ b/crates/benchmarks/benches/1-map.rs
@@ -47,42 +47,6 @@ mod toml_parse {
                 }
 
                 impl ::toml_parse::parser::EventReceiver for Void<'_> {
-                    fn comment(
-                        &mut self,
-                        span: ::toml_parse::Span,
-                        error: &mut dyn ::toml_parse::ErrorSink,
-                    ) {
-                        let event = ::toml_parse::parser::Event::new_unchecked(
-                            ::toml_parse::parser::EventKind::Comment,
-                            None,
-                            span,
-                        );
-                        #[cfg(feature = "unsafe")]
-                        // SAFETY: `EventReceiver` should always receive valid
-                        // spans
-                        let raw = unsafe { self.source.get_unchecked(event) };
-                        #[cfg(not(feature = "unsafe"))]
-                        let raw = self.source.get(event).unwrap();
-                        raw.decode_comment(error);
-                    }
-                    fn newline(
-                        &mut self,
-                        span: ::toml_parse::Span,
-                        error: &mut dyn ::toml_parse::ErrorSink,
-                    ) {
-                        let event = ::toml_parse::parser::Event::new_unchecked(
-                            ::toml_parse::parser::EventKind::Comment,
-                            None,
-                            span,
-                        );
-                        #[cfg(feature = "unsafe")]
-                        // SAFETY: `EventReceiver` should always receive valid
-                        // spans
-                        let raw = unsafe { self.source.get_unchecked(event) };
-                        #[cfg(not(feature = "unsafe"))]
-                        let raw = self.source.get(event).unwrap();
-                        raw.decode_newline(error);
-                    }
                     fn simple_key(
                         &mut self,
                         span: ::toml_parse::Span,
@@ -130,7 +94,8 @@ mod toml_parse {
                 let tokens = source.lex().into_vec();
                 let mut errors = Vec::new();
                 let mut events = Void { source: &source };
-                ::toml_parse::parser::parse_document(&tokens, &mut events, &mut errors);
+                let mut receiver = toml_parse::parser::ValidateWhitespace::new(&mut events, source);
+                ::toml_parse::parser::parse_document(&tokens, &mut receiver, &mut errors);
             });
     }
 }

--- a/crates/benchmarks/benches/2-array.rs
+++ b/crates/benchmarks/benches/2-array.rs
@@ -47,42 +47,6 @@ mod toml_parse {
                 }
 
                 impl ::toml_parse::parser::EventReceiver for Void<'_> {
-                    fn comment(
-                        &mut self,
-                        span: ::toml_parse::Span,
-                        error: &mut dyn ::toml_parse::ErrorSink,
-                    ) {
-                        let event = ::toml_parse::parser::Event::new_unchecked(
-                            ::toml_parse::parser::EventKind::Comment,
-                            None,
-                            span,
-                        );
-                        #[cfg(feature = "unsafe")]
-                        // SAFETY: `EventReceiver` should always receive valid
-                        // spans
-                        let raw = unsafe { self.source.get_unchecked(event) };
-                        #[cfg(not(feature = "unsafe"))]
-                        let raw = self.source.get(event).unwrap();
-                        raw.decode_comment(error);
-                    }
-                    fn newline(
-                        &mut self,
-                        span: ::toml_parse::Span,
-                        error: &mut dyn ::toml_parse::ErrorSink,
-                    ) {
-                        let event = ::toml_parse::parser::Event::new_unchecked(
-                            ::toml_parse::parser::EventKind::Comment,
-                            None,
-                            span,
-                        );
-                        #[cfg(feature = "unsafe")]
-                        // SAFETY: `EventReceiver` should always receive valid
-                        // spans
-                        let raw = unsafe { self.source.get_unchecked(event) };
-                        #[cfg(not(feature = "unsafe"))]
-                        let raw = self.source.get(event).unwrap();
-                        raw.decode_newline(error);
-                    }
                     fn simple_key(
                         &mut self,
                         span: ::toml_parse::Span,
@@ -130,7 +94,8 @@ mod toml_parse {
                 let tokens = source.lex().into_vec();
                 let mut errors = Vec::new();
                 let mut events = Void { source: &source };
-                ::toml_parse::parser::parse_document(&tokens, &mut events, &mut errors);
+                let mut receiver = toml_parse::parser::ValidateWhitespace::new(&mut events, source);
+                ::toml_parse::parser::parse_document(&tokens, &mut receiver, &mut errors);
             });
     }
 }

--- a/crates/toml_parse/src/parser/mod.rs
+++ b/crates/toml_parse/src/parser/mod.rs
@@ -9,3 +9,4 @@ pub use event::Event;
 pub use event::EventKind;
 pub use event::EventReceiver;
 pub use event::RecursionGuard;
+pub use event::ValidateWhitespace;

--- a/crates/toml_parse/src/source.rs
+++ b/crates/toml_parse/src/source.rs
@@ -143,6 +143,10 @@ impl<'i> Raw<'i> {
         }
     }
 
+    pub fn decode_whitespace(&self, _error: &mut dyn ErrorSink) {
+        // whitespace is always valid
+    }
+
     pub fn decode_comment(&self, error: &mut dyn ErrorSink) {
         let mut error = |mut err: crate::ParseError| {
             err.context += self.span.start;


### PR DESCRIPTION
This slows `0_cargo::toml_parse::decoded::2-features` down from 153us to 163us