### PR TITLE
fix(datetime): Improve error message quality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ name = "toml_datetime"
 version = "0.6.9"
 dependencies = [
  "serde",
+ "snapbox",
 ]
 
 [[package]]

--- a/crates/toml_datetime/Cargo.toml
+++ b/crates/toml_datetime/Cargo.toml
@@ -30,3 +30,6 @@ serde = { version = "1.0.145", optional = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+snapbox = "0.6.21"

--- a/crates/toml_datetime/src/datetime.rs
+++ b/crates/toml_datetime/src/datetime.rs
@@ -493,6 +493,13 @@ impl FromStr for Datetime {
                 let hours = h1 * 10 + h2;
                 let minutes = m1 * 10 + m2;
 
+                if hours > 23 {
+                    return Err(DatetimeParseError {});
+                }
+                if minutes > 59 {
+                    return Err(DatetimeParseError {});
+                }
+
                 let total_minutes = sign * (hours * 60 + minutes);
 
                 if !((-24 * 60)..=(24 * 60)).contains(&total_minutes) {

--- a/crates/toml_datetime/src/datetime.rs
+++ b/crates/toml_datetime/src/datetime.rs
@@ -339,13 +339,10 @@ impl FromStr for Datetime {
         if date.len() < 3 {
             return Err(DatetimeParseError {});
         }
-        let mut offset_allowed = true;
         let mut chars = date.chars();
 
         // First up, parse the full date if we can
-        if chars.clone().nth(2) == Some(':') {
-            offset_allowed = false;
-        } else {
+        if chars.clone().nth(2) != Some(':') {
             let y1 = u16::from(digit(&mut chars)?);
             let y2 = u16::from(digit(&mut chars)?);
             let y3 = u16::from(digit(&mut chars)?);
@@ -467,12 +464,10 @@ impl FromStr for Datetime {
             }
 
             result.time = Some(time);
-        } else {
-            offset_allowed = false;
         }
 
         // And finally, parse the offset
-        if offset_allowed {
+        if result.date.is_some() && result.time.is_some() {
             let next = chars.clone().next();
             let offset = if next == Some('Z') || next == Some('z') {
                 chars.next();

--- a/crates/toml_datetime/src/datetime.rs
+++ b/crates/toml_datetime/src/datetime.rs
@@ -449,7 +449,7 @@ impl FromStr for Datetime {
                 nanosecond,
             };
 
-            if time.hour > 24 {
+            if time.hour > 23 {
                 return Err(DatetimeParseError {});
             }
             if time.minute > 59 {

--- a/crates/toml_datetime/src/datetime.rs
+++ b/crates/toml_datetime/src/datetime.rs
@@ -338,35 +338,38 @@ impl FromStr for Datetime {
 
         let mut lexer = Lexer::new(date);
 
-        let digits = lexer.next().ok_or(DatetimeParseError {})?;
+        let digits = lexer.next().ok_or(DatetimeParseError::new())?;
         digits.is(TokenKind::Digits)?;
-        let sep = lexer.next().ok_or(DatetimeParseError {})?;
+        let sep = lexer.next().ok_or(DatetimeParseError::new())?;
         match sep.kind {
             TokenKind::Dash => {
                 let year = digits;
-                let month = lexer.next().ok_or(DatetimeParseError {})?;
+                let month = lexer.next().ok_or(DatetimeParseError::new())?;
                 month.is(TokenKind::Digits)?;
-                let sep = lexer.next().ok_or(DatetimeParseError {})?;
+                let sep = lexer.next().ok_or(DatetimeParseError::new())?;
                 sep.is(TokenKind::Dash)?;
-                let day = lexer.next().ok_or(DatetimeParseError {})?;
+                let day = lexer.next().ok_or(DatetimeParseError::new())?;
                 day.is(TokenKind::Digits)?;
 
                 if year.raw.len() != 4 {
-                    return Err(DatetimeParseError {});
+                    return Err(DatetimeParseError::new());
                 }
                 if month.raw.len() != 2 {
-                    return Err(DatetimeParseError {});
+                    return Err(DatetimeParseError::new());
                 }
                 if day.raw.len() != 2 {
-                    return Err(DatetimeParseError {});
+                    return Err(DatetimeParseError::new());
                 }
                 let date = Date {
-                    year: year.raw.parse().map_err(|_err| DatetimeParseError {})?,
-                    month: month.raw.parse().map_err(|_err| DatetimeParseError {})?,
-                    day: day.raw.parse().map_err(|_err| DatetimeParseError {})?,
+                    year: year.raw.parse().map_err(|_err| DatetimeParseError::new())?,
+                    month: month
+                        .raw
+                        .parse()
+                        .map_err(|_err| DatetimeParseError::new())?,
+                    day: day.raw.parse().map_err(|_err| DatetimeParseError::new())?,
                 };
                 if date.month < 1 || date.month > 12 {
-                    return Err(DatetimeParseError {});
+                    return Err(DatetimeParseError::new());
                 }
                 let is_leap_year =
                     (date.year % 4 == 0) && ((date.year % 100 != 0) || (date.year % 400 == 0));
@@ -377,14 +380,14 @@ impl FromStr for Datetime {
                     _ => 31,
                 };
                 if date.day < 1 || date.day > max_days_in_month {
-                    return Err(DatetimeParseError {});
+                    return Err(DatetimeParseError::new());
                 }
 
                 result.date = Some(date);
             }
             TokenKind::Colon => lexer = Lexer::new(date),
             _ => {
-                return Err(DatetimeParseError {});
+                return Err(DatetimeParseError::new());
             }
         }
 
@@ -394,7 +397,7 @@ impl FromStr for Datetime {
             match sep {
                 Some(token) if matches!(token.kind, TokenKind::T | TokenKind::Space) => true,
                 Some(_token) => {
-                    return Err(DatetimeParseError {});
+                    return Err(DatetimeParseError::new());
                 }
                 None => false,
             }
@@ -403,21 +406,21 @@ impl FromStr for Datetime {
         };
 
         if partial_time {
-            let hour = lexer.next().ok_or(DatetimeParseError {})?;
+            let hour = lexer.next().ok_or(DatetimeParseError::new())?;
             hour.is(TokenKind::Digits)?;
-            let sep = lexer.next().ok_or(DatetimeParseError {})?;
+            let sep = lexer.next().ok_or(DatetimeParseError::new())?;
             sep.is(TokenKind::Colon)?;
-            let minute = lexer.next().ok_or(DatetimeParseError {})?;
+            let minute = lexer.next().ok_or(DatetimeParseError::new())?;
             minute.is(TokenKind::Digits)?;
-            let sep = lexer.next().ok_or(DatetimeParseError {})?;
+            let sep = lexer.next().ok_or(DatetimeParseError::new())?;
             sep.is(TokenKind::Colon)?;
-            let second = lexer.next().ok_or(DatetimeParseError {})?;
+            let second = lexer.next().ok_or(DatetimeParseError::new())?;
             second.is(TokenKind::Digits)?;
 
             let nanosecond = if lexer.clone().next().map(|t| t.kind) == Some(TokenKind::Dot) {
-                let sep = lexer.next().ok_or(DatetimeParseError {})?;
+                let sep = lexer.next().ok_or(DatetimeParseError::new())?;
                 sep.is(TokenKind::Dot)?;
-                let nanosecond = lexer.next().ok_or(DatetimeParseError {})?;
+                let nanosecond = lexer.next().ok_or(DatetimeParseError::new())?;
                 nanosecond.is(TokenKind::Digits)?;
                 Some(nanosecond)
             } else {
@@ -425,34 +428,40 @@ impl FromStr for Datetime {
             };
 
             if hour.raw.len() != 2 {
-                return Err(DatetimeParseError {});
+                return Err(DatetimeParseError::new());
             }
             if minute.raw.len() != 2 {
-                return Err(DatetimeParseError {});
+                return Err(DatetimeParseError::new());
             }
             if second.raw.len() != 2 {
-                return Err(DatetimeParseError {});
+                return Err(DatetimeParseError::new());
             }
 
             let time = Time {
-                hour: hour.raw.parse().map_err(|_err| DatetimeParseError {})?,
-                minute: minute.raw.parse().map_err(|_err| DatetimeParseError {})?,
-                second: second.raw.parse().map_err(|_err| DatetimeParseError {})?,
+                hour: hour.raw.parse().map_err(|_err| DatetimeParseError::new())?,
+                minute: minute
+                    .raw
+                    .parse()
+                    .map_err(|_err| DatetimeParseError::new())?,
+                second: second
+                    .raw
+                    .parse()
+                    .map_err(|_err| DatetimeParseError::new())?,
                 nanosecond: nanosecond.map(|t| s_to_nanoseconds(t.raw)).unwrap_or(0),
             };
 
             if time.hour > 23 {
-                return Err(DatetimeParseError {});
+                return Err(DatetimeParseError::new());
             }
             if time.minute > 59 {
-                return Err(DatetimeParseError {});
+                return Err(DatetimeParseError::new());
             }
             // 00-58, 00-59, 00-60 based on leap second rules
             if time.second > 60 {
-                return Err(DatetimeParseError {});
+                return Err(DatetimeParseError::new());
             }
             if time.nanosecond > 999_999_999 {
-                return Err(DatetimeParseError {});
+                return Err(DatetimeParseError::new());
             }
 
             result.time = Some(time);
@@ -466,40 +475,40 @@ impl FromStr for Datetime {
                 }
                 Some(token) if matches!(token.kind, TokenKind::Plus | TokenKind::Dash) => {
                     let sign = if token.kind == TokenKind::Plus { 1 } else { -1 };
-                    let hours = lexer.next().ok_or(DatetimeParseError {})?;
+                    let hours = lexer.next().ok_or(DatetimeParseError::new())?;
                     hours.is(TokenKind::Digits)?;
-                    let sep = lexer.next().ok_or(DatetimeParseError {})?;
+                    let sep = lexer.next().ok_or(DatetimeParseError::new())?;
                     sep.is(TokenKind::Colon)?;
-                    let minutes = lexer.next().ok_or(DatetimeParseError {})?;
+                    let minutes = lexer.next().ok_or(DatetimeParseError::new())?;
                     minutes.is(TokenKind::Digits)?;
 
                     if hours.raw.len() != 2 {
-                        return Err(DatetimeParseError {});
+                        return Err(DatetimeParseError::new());
                     }
                     if minutes.raw.len() != 2 {
-                        return Err(DatetimeParseError {});
+                        return Err(DatetimeParseError::new());
                     }
 
                     let hours = hours
                         .raw
                         .parse::<u8>()
-                        .map_err(|_err| DatetimeParseError {})?;
+                        .map_err(|_err| DatetimeParseError::new())?;
                     let minutes = minutes
                         .raw
                         .parse::<u8>()
-                        .map_err(|_err| DatetimeParseError {})?;
+                        .map_err(|_err| DatetimeParseError::new())?;
 
                     if hours > 23 {
-                        return Err(DatetimeParseError {});
+                        return Err(DatetimeParseError::new());
                     }
                     if minutes > 59 {
-                        return Err(DatetimeParseError {});
+                        return Err(DatetimeParseError::new());
                     }
 
                     let total_minutes = sign * (hours as i16 * 60 + minutes as i16);
 
                     if !((-24 * 60)..=(24 * 60)).contains(&total_minutes) {
-                        return Err(DatetimeParseError {});
+                        return Err(DatetimeParseError::new());
                     }
 
                     result.offset = Some(Offset::Custom {
@@ -507,7 +516,7 @@ impl FromStr for Datetime {
                     });
                 }
                 Some(_token) => {
-                    return Err(DatetimeParseError {});
+                    return Err(DatetimeParseError::new());
                 }
                 None => {}
             }
@@ -516,7 +525,7 @@ impl FromStr for Datetime {
         // Return an error if we didn't hit eof, otherwise return our parsed
         // date
         if lexer.unknown().is_some() {
-            return Err(DatetimeParseError {});
+            return Err(DatetimeParseError::new());
         }
 
         Ok(result)
@@ -549,7 +558,7 @@ impl Token<'_> {
         if self.kind == kind {
             Ok(())
         } else {
-            Err(DatetimeParseError {})
+            Err(DatetimeParseError::new())
         }
     }
 }
@@ -624,6 +633,12 @@ impl<'s> Iterator for Lexer<'s> {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct DatetimeParseError {}
+
+impl DatetimeParseError {
+    fn new() -> Self {
+        Self {}
+    }
+}
 
 impl fmt::Display for DatetimeParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/toml_datetime/src/datetime.rs
+++ b/crates/toml_datetime/src/datetime.rs
@@ -293,6 +293,43 @@ impl FromStr for Datetime {
         // 0000-00-00T00:00:00.00
         // 0000-00-00
         // 00:00:00.00
+        //
+        // ```abnf
+        // ;; Date and Time (as defined in RFC 3339)
+        //
+        // date-time      = offset-date-time / local-date-time / local-date / local-time
+        //
+        // date-fullyear  = 4DIGIT
+        // date-month     = 2DIGIT  ; 01-12
+        // date-mday      = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on month/year
+        // time-delim     = "T" / %x20 ; T, t, or space
+        // time-hour      = 2DIGIT  ; 00-23
+        // time-minute    = 2DIGIT  ; 00-59
+        // time-second    = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second rules
+        // time-secfrac   = "." 1*DIGIT
+        // time-numoffset = ( "+" / "-" ) time-hour ":" time-minute
+        // time-offset    = "Z" / time-numoffset
+        //
+        // partial-time   = time-hour ":" time-minute ":" time-second [ time-secfrac ]
+        // full-date      = date-fullyear "-" date-month "-" date-mday
+        // full-time      = partial-time time-offset
+        //
+        // ;; Offset Date-Time
+        //
+        // offset-date-time = full-date time-delim full-time
+        //
+        // ;; Local Date-Time
+        //
+        // local-date-time = full-date time-delim partial-time
+        //
+        // ;; Local Date
+        //
+        // local-date = full-date
+        //
+        // ;; Local Time
+        //
+        // local-time = partial-time
+        // ```
         if date.len() < 3 {
             return Err(DatetimeParseError {});
         }

--- a/crates/toml_datetime/src/datetime.rs
+++ b/crates/toml_datetime/src/datetime.rs
@@ -92,11 +92,6 @@ pub struct Datetime {
     pub offset: Option<Offset>,
 }
 
-/// Error returned from parsing a `Datetime` in the `FromStr` implementation.
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct DatetimeParseError {}
-
 // Currently serde itself doesn't have a datetime type, so we map our `Datetime`
 // to a special value in the serde data model. Namely one with these special
 // fields/struct names.
@@ -497,6 +492,19 @@ fn digit(chars: &mut str::Chars<'_>) -> Result<u8, DatetimeParseError> {
     }
 }
 
+/// Error returned from parsing a `Datetime` in the `FromStr` implementation.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct DatetimeParseError {}
+
+impl fmt::Display for DatetimeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "failed to parse datetime".fmt(f)
+    }
+}
+
+impl error::Error for DatetimeParseError {}
+
 #[cfg(feature = "serde")]
 impl ser::Serialize for Datetime {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -674,11 +682,3 @@ impl<'de> de::Deserialize<'de> for DatetimeFromString {
         deserializer.deserialize_str(Visitor)
     }
 }
-
-impl fmt::Display for DatetimeParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        "failed to parse datetime".fmt(f)
-    }
-}
-
-impl error::Error for DatetimeParseError {}

--- a/crates/toml_datetime/tests/parse.rs
+++ b/crates/toml_datetime/tests/parse.rs
@@ -1,0 +1,62 @@
+use snapbox::prelude::*;
+use snapbox::str;
+
+#[track_caller]
+fn t(input: &str, expected: impl IntoData) {
+    let actual = input.parse::<toml_datetime::Datetime>();
+    snapbox::assert_data_eq!(actual.to_debug(), expected.raw());
+}
+
+#[test]
+fn only_t() {
+    t(
+        "T",
+        str![[r#"
+Err(
+    DatetimeParseError {
+        what: None,
+        expected: Some(
+            "year or hour",
+        ),
+    },
+)
+
+"#]],
+    );
+}
+
+#[test]
+fn only_tz() {
+    t(
+        "TZ",
+        str![[r#"
+Err(
+    DatetimeParseError {
+        what: None,
+        expected: Some(
+            "year or hour",
+        ),
+    },
+)
+
+"#]],
+    );
+}
+
+#[test]
+fn only_tz_dot() {
+    t(
+        "TZ.",
+        str![[r#"
+Err(
+    DatetimeParseError {
+        what: None,
+        expected: Some(
+            "year or hour",
+        ),
+    },
+)
+
+"#]],
+    );
+}


### PR DESCRIPTION
This includes fixing some validation bugs in the parser.

The parser is effectively untested at this time.  I have some experimental changes that allow running the TOML conformance tests on this parser which is how I validated this.  My hope is we'll switch exclusively to parsing using `toml_datetime`s parser.

This doesn't add span tracking to get the same level of quality of error messages as the `winnow` parser in `toml_edit` but I'm hoping that that is ok.

There is also some bad error messages when it comes to months with a max day below 31.