### PR TITLE
fix(parse): Ensure values get validated

### DIFF
--- a/crates/toml_parse/src/decoder/scalar.rs
+++ b/crates/toml_parse/src/decoder/scalar.rs
@@ -223,7 +223,8 @@ pub(crate) fn decode_zero_prefix<'i>(
         let kind = ScalarKind::Integer(IntegerRadix::Dec);
         decode_float_or_integer(raw.as_str(), raw, kind, output, error)
     } else {
-        match value.as_bytes()[1] {
+        let radix = value.as_bytes()[1];
+        match radix {
             b'x' | b'X' => {
                 if signed {
                     error.report_error(
@@ -231,6 +232,16 @@ pub(crate) fn decode_zero_prefix<'i>(
                             .with_context(Span::new_unchecked(0, raw.len()))
                             .with_expected(&[])
                             .with_unexpected(Span::new_unchecked(0, 1)),
+                    );
+                }
+                if radix == b'X' {
+                    let start = value.offset_from(&raw.as_str());
+                    let end = start + 2;
+                    error.report_error(
+                        ParseError::new("radix must be lowercase")
+                            .with_context(Span::new_unchecked(0, raw.len()))
+                            .with_expected(&[Expected::Literal("0x")])
+                            .with_unexpected(Span::new_unchecked(start, end)),
                     );
                 }
                 let radix = IntegerRadix::Hex;
@@ -248,6 +259,16 @@ pub(crate) fn decode_zero_prefix<'i>(
                             .with_unexpected(Span::new_unchecked(0, 1)),
                     );
                 }
+                if radix == b'O' {
+                    let start = value.offset_from(&raw.as_str());
+                    let end = start + 2;
+                    error.report_error(
+                        ParseError::new("radix must be lowercase")
+                            .with_context(Span::new_unchecked(0, raw.len()))
+                            .with_expected(&[Expected::Literal("0o")])
+                            .with_unexpected(Span::new_unchecked(start, end)),
+                    );
+                }
                 let radix = IntegerRadix::Oct;
                 let kind = ScalarKind::Integer(radix);
                 let stream = &value[2..];
@@ -261,6 +282,16 @@ pub(crate) fn decode_zero_prefix<'i>(
                             .with_context(Span::new_unchecked(0, raw.len()))
                             .with_expected(&[])
                             .with_unexpected(Span::new_unchecked(0, 1)),
+                    );
+                }
+                if radix == b'B' {
+                    let start = value.offset_from(&raw.as_str());
+                    let end = start + 2;
+                    error.report_error(
+                        ParseError::new("radix must be lowercase")
+                            .with_context(Span::new_unchecked(0, raw.len()))
+                            .with_expected(&[Expected::Literal("0b")])
+                            .with_unexpected(Span::new_unchecked(start, end)),
                     );
                 }
                 let radix = IntegerRadix::Bin;

--- a/crates/toml_parse/src/decoder/scalar.rs
+++ b/crates/toml_parse/src/decoder/scalar.rs
@@ -221,6 +221,7 @@ pub(crate) fn decode_zero_prefix<'i>(
     debug_assert_eq!(value.as_bytes()[0], b'0');
     if value.len() == 1 {
         let kind = ScalarKind::Integer(IntegerRadix::Dec);
+        // No extra validation needed
         decode_float_or_integer(raw.as_str(), raw, kind, output, error)
     } else {
         let radix = value.as_bytes()[1];

--- a/crates/toml_parse/src/decoder/scalar.rs
+++ b/crates/toml_parse/src/decoder/scalar.rs
@@ -101,9 +101,9 @@ pub(crate) fn decode_unquoted_scalar<'i>(
     };
     match first {
         // number starts
-        b'+' | b'-' |
+        b'+' | b'-' => decode_sign_prefix(raw, output, error),
         // Report as if they were numbers because its most likely a typo
-        b'_' => decode_sign_prefix(raw, output, error),
+        b'_' => decode_datetime_or_float_or_integer(raw, output, error),
         // Date/number starts
         b'0' => decode_zero_prefix(raw, output, error),
         b'1'..=b'9' => decode_datetime_or_float_or_integer(raw, output, error),

--- a/crates/toml_parse/src/decoder/scalar.rs
+++ b/crates/toml_parse/src/decoder/scalar.rs
@@ -101,7 +101,10 @@ pub(crate) fn decode_unquoted_scalar<'i>(
     };
     match first {
         // number starts
-        b'+' | b'-' => decode_sign_prefix(raw, output, error),
+        b'+' | b'-' => {
+            let value = &raw.as_str()[1..];
+            decode_sign_prefix(raw, value, output, error)
+        }
         // Report as if they were numbers because its most likely a typo
         b'_' => decode_datetime_or_float_or_integer(raw, output, error),
         // Date/number starts
@@ -139,13 +142,11 @@ pub(crate) fn decode_unquoted_scalar<'i>(
 
 pub(crate) fn decode_sign_prefix<'i>(
     raw: Raw<'i>,
+    value: &'i str,
     output: &mut dyn StringBuilder<'i>,
     error: &mut dyn ErrorSink,
 ) -> ScalarKind {
-    #[cfg(feature = "unsafe")] // SAFETY: ascii digit ensures UTF-8 boundary
-    let rest = unsafe { raw.as_str().get_unchecked(1..) };
-    #[cfg(not(feature = "unsafe"))]
-    let rest = &raw.as_str()[1..];
+    let rest = value;
 
     if rest.starts_with(['n', 'N']) {
         const SYMBOL: &str = "nan";

--- a/crates/toml_parse/src/decoder/scalar.rs
+++ b/crates/toml_parse/src/decoder/scalar.rs
@@ -148,8 +148,8 @@ pub(crate) fn decode_sign_prefix<'i>(
 ) -> ScalarKind {
     let rest = value;
 
-    if rest.starts_with(['n', 'N']) {
-        const SYMBOL: &str = "nan";
+    if rest.starts_with(['i', 'I']) {
+        const SYMBOL: &str = "inf";
         let kind = ScalarKind::Float;
         if rest != SYMBOL {
             let expected = &[Expected::Literal(SYMBOL)];
@@ -165,8 +165,8 @@ pub(crate) fn decode_sign_prefix<'i>(
         } else {
             decode_as_is(raw, kind, output, error)
         }
-    } else if rest.starts_with(['i', 'I']) {
-        const SYMBOL: &str = "inf";
+    } else if rest.starts_with(['n', 'N']) {
+        const SYMBOL: &str = "nan";
         let kind = ScalarKind::Float;
         if rest != SYMBOL {
             let expected = &[Expected::Literal(SYMBOL)];

--- a/crates/toml_parse/src/decoder/scalar.rs
+++ b/crates/toml_parse/src/decoder/scalar.rs
@@ -137,57 +137,6 @@ pub(crate) fn decode_unquoted_scalar<'i>(
     }
 }
 
-pub(crate) fn decode_zero_prefix<'i>(
-    raw: Raw<'i>,
-    output: &mut dyn StringBuilder<'i>,
-    error: &mut dyn ErrorSink,
-) -> ScalarKind {
-    let s = raw.as_str();
-    debug_assert_eq!(s.as_bytes()[0], b'0');
-    if s.len() == 1 {
-        let kind = ScalarKind::Integer(IntegerRadix::Dec);
-        decode_float_or_integer(raw.as_str(), raw, kind, output, error)
-    } else {
-        match s.as_bytes()[1] {
-            b'x' | b'X' => {
-                let radix = IntegerRadix::Hex;
-                let kind = ScalarKind::Integer(radix);
-                let stream = &raw.as_str()[2..];
-                ensure_radixed_value(stream, raw, radix, error);
-                decode_float_or_integer(stream, raw, kind, output, error)
-            }
-            b'o' | b'O' => {
-                let radix = IntegerRadix::Oct;
-                let kind = ScalarKind::Integer(radix);
-                let stream = &raw.as_str()[2..];
-                ensure_radixed_value(stream, raw, radix, error);
-                decode_float_or_integer(stream, raw, kind, output, error)
-            }
-            b'b' | b'B' => {
-                let radix = IntegerRadix::Bin;
-                let kind = ScalarKind::Integer(radix);
-                let stream = &raw.as_str()[2..];
-                ensure_radixed_value(stream, raw, radix, error);
-                decode_float_or_integer(stream, raw, kind, output, error)
-            }
-            b'd' | b'D' => {
-                let radix = IntegerRadix::Dec;
-                let kind = ScalarKind::Integer(radix);
-                let stream = &raw.as_str()[2..];
-                error.report_error(
-                    ParseError::new("redundant integer number prefix")
-                        .with_context(Span::new_unchecked(0, raw.len()))
-                        .with_expected(&[])
-                        .with_unexpected(Span::new_unchecked(0, 2)),
-                );
-                ensure_radixed_value(stream, raw, radix, error);
-                decode_float_or_integer(stream, raw, kind, output, error)
-            }
-            _ => decode_datetime_or_float_or_integer(raw, output, error),
-        }
-    }
-}
-
 pub(crate) fn decode_sign_prefix<'i>(
     raw: Raw<'i>,
     output: &mut dyn StringBuilder<'i>,
@@ -238,6 +187,57 @@ pub(crate) fn decode_sign_prefix<'i>(
     } else {
         let kind = ScalarKind::Integer(IntegerRadix::Dec);
         decode_float_or_integer(raw.as_str(), raw, kind, output, error)
+    }
+}
+
+pub(crate) fn decode_zero_prefix<'i>(
+    raw: Raw<'i>,
+    output: &mut dyn StringBuilder<'i>,
+    error: &mut dyn ErrorSink,
+) -> ScalarKind {
+    let s = raw.as_str();
+    debug_assert_eq!(s.as_bytes()[0], b'0');
+    if s.len() == 1 {
+        let kind = ScalarKind::Integer(IntegerRadix::Dec);
+        decode_float_or_integer(raw.as_str(), raw, kind, output, error)
+    } else {
+        match s.as_bytes()[1] {
+            b'x' | b'X' => {
+                let radix = IntegerRadix::Hex;
+                let kind = ScalarKind::Integer(radix);
+                let stream = &raw.as_str()[2..];
+                ensure_radixed_value(stream, raw, radix, error);
+                decode_float_or_integer(stream, raw, kind, output, error)
+            }
+            b'o' | b'O' => {
+                let radix = IntegerRadix::Oct;
+                let kind = ScalarKind::Integer(radix);
+                let stream = &raw.as_str()[2..];
+                ensure_radixed_value(stream, raw, radix, error);
+                decode_float_or_integer(stream, raw, kind, output, error)
+            }
+            b'b' | b'B' => {
+                let radix = IntegerRadix::Bin;
+                let kind = ScalarKind::Integer(radix);
+                let stream = &raw.as_str()[2..];
+                ensure_radixed_value(stream, raw, radix, error);
+                decode_float_or_integer(stream, raw, kind, output, error)
+            }
+            b'd' | b'D' => {
+                let radix = IntegerRadix::Dec;
+                let kind = ScalarKind::Integer(radix);
+                let stream = &raw.as_str()[2..];
+                error.report_error(
+                    ParseError::new("redundant integer number prefix")
+                        .with_context(Span::new_unchecked(0, raw.len()))
+                        .with_expected(&[])
+                        .with_unexpected(Span::new_unchecked(0, 2)),
+                );
+                ensure_radixed_value(stream, raw, radix, error);
+                decode_float_or_integer(stream, raw, kind, output, error)
+            }
+            _ => decode_datetime_or_float_or_integer(raw, output, error),
+        }
     }
 }
 

--- a/crates/toml_parse/src/decoder/scalar.rs
+++ b/crates/toml_parse/src/decoder/scalar.rs
@@ -336,6 +336,16 @@ pub(crate) fn decode_datetime_or_float_or_integer<'i>(
         .as_bytes()
         .offset_for(|b| !(b'0'..=b'9').contains_token(b))
     else {
+        if value.starts_with("0") {
+            let start = value.offset_from(&raw.as_str());
+            let end = start + 1;
+            error.report_error(
+                ParseError::new("unexpected leading zero")
+                    .with_context(Span::new_unchecked(0, raw.len()))
+                    .with_expected(&[])
+                    .with_unexpected(Span::new_unchecked(start, end)),
+            );
+        }
         let kind = ScalarKind::Integer(IntegerRadix::Dec);
         let stream = raw.as_str();
         return decode_float_or_integer(stream, raw, kind, output, error);

--- a/crates/toml_parse/tests/snapshots/testsuite__parse_value__integer_hex_neg.txt
+++ b/crates/toml_parse/tests/snapshots/testsuite__parse_value__integer_hex_neg.txt
@@ -1,0 +1,24 @@
+EventResults {
+    input: "0x-F",
+    events: [
+        Event {
+            kind: Scalar,
+            encoding: None,
+            span: 0..4,
+        },
+    ],
+    errors: [
+        ParseError {
+            context: Some(
+                0..4,
+            ),
+            description: "unexpected sign",
+            expected: Some(
+                [],
+            ),
+            unexpected: Some(
+                2..3,
+            ),
+        },
+    ],
+}

--- a/crates/toml_parse/tests/snapshots/testsuite__parse_value__integer_neg_hex.txt
+++ b/crates/toml_parse/tests/snapshots/testsuite__parse_value__integer_neg_hex.txt
@@ -12,10 +12,12 @@ EventResults {
             context: Some(
                 0..4,
             ),
-            description: "failed to parse i64",
-            expected: None,
+            description: "integers with a radix cannot be signed",
+            expected: Some(
+                [],
+            ),
             unexpected: Some(
-                0..2,
+                0..1,
             ),
         },
     ],

--- a/crates/toml_parse/tests/snapshots/testsuite__parse_value__integer_neg_hex.txt
+++ b/crates/toml_parse/tests/snapshots/testsuite__parse_value__integer_neg_hex.txt
@@ -1,0 +1,22 @@
+EventResults {
+    input: "-0xF",
+    events: [
+        Event {
+            kind: Scalar,
+            encoding: None,
+            span: 0..4,
+        },
+    ],
+    errors: [
+        ParseError {
+            context: Some(
+                0..4,
+            ),
+            description: "failed to parse i64",
+            expected: None,
+            unexpected: Some(
+                0..2,
+            ),
+        },
+    ],
+}

--- a/crates/toml_parse/tests/testsuite/parse_value.rs
+++ b/crates/toml_parse/tests/testsuite/parse_value.rs
@@ -377,6 +377,16 @@ fn integer_hex() {
 }
 
 #[test]
+fn integer_hex_neg() {
+    t("0x-F", file![_].raw());
+}
+
+#[test]
+fn integer_neg_hex() {
+    t("-0xF", file![_].raw());
+}
+
+#[test]
 fn integer_oct_sep() {
     t("0o0_755", file![_].raw());
 }


### PR DESCRIPTION
I was banking on Rust and Toml having more similar rules.  That isn't a good assumption to make and it was wrong.