### PR TITLE
fix(edit): Implicitly convert tables, rather than throwaway

### DIFF
--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -71,6 +71,9 @@ impl InlineTable {
                 Item::Value(value) => {
                     values.push((path, value));
                 }
+                Item::Table(table) => {
+                    table.append_all_values(&path, values);
+                }
                 _ => {}
             }
         }

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -1465,3 +1465,18 @@ fn assert_key_value_roundtrip(input: &str, expected: impl IntoData) {
     });
     assert_data_eq!(actual, expected.raw());
 }
+
+#[test]
+fn table_under_inline() {
+    let mut doc = DocumentMut::new();
+    doc["tool"]["typst-test"] = table();
+    doc["tool"]["typst-test"]["tests"] = value("tests");
+
+    assert_data_eq!(
+        doc.to_string(),
+        str![[r#"
+tool = {}
+
+"#]]
+    );
+}

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -1475,7 +1475,7 @@ fn table_under_inline() {
     assert_data_eq!(
         doc.to_string(),
         str![[r#"
-tool = {}
+tool = { typst-test.tests = "tests" }
 
 "#]]
     );


### PR DESCRIPTION
I believe this will help with cases like #762.

I've had this branch sitting around for a while and I'm unsure why I never moved forward with it.  Maybe because this glosses over user bugs?  Except we allow this kind of sloppiness in other cases.