### PR TITLE
refactor: try literal strings before basic for TomlKey

### DIFF
--- a/crates/toml_write/src/string.rs
+++ b/crates/toml_write/src/string.rs
@@ -122,8 +122,8 @@ impl<'s> TomlKeyBuilder<'s> {
 
     pub fn as_default(&self) -> TomlKey<'s> {
         self.as_unquoted()
-            .or_else(|| self.as_basic_pretty())
             .or_else(|| self.as_literal())
+            .or_else(|| self.as_basic_pretty())
             .unwrap_or_else(|| self.as_basic())
     }
 

--- a/crates/toml_write/tests/string.rs
+++ b/crates/toml_write/tests/string.rs
@@ -73,7 +73,7 @@ fn empty() {
         str![[r#"
 StringResults {
     decoded: "",
-    key_default: "\"\"",
+    key_default: "''",
     key_unquoted: None,
     key_literal: Some(
         "''",
@@ -548,7 +548,7 @@ fn tab() {
         str![[r#"
 StringResults {
     decoded: "\thello\tworld\t",
-    key_default: "\"\\thello\\tworld\\t\"",
+    key_default: "'\thello\tworld\t'",
     key_unquoted: None,
     key_literal: Some(
         "'\thello\tworld\t'",


### PR DESCRIPTION
Basic (`"in double quotes"`) strings are more powerful than literal (`'in single quotes'`) strings in representing keys, and unquoted (bare) strings are the least powerful. This patch makes sure we use the least possible representation for keys: try unquoted strings, then literal, then basic.