### PR TITLE
bench(toml): Parse as Table, not value

### DIFF
--- a/crates/benchmarks/benches/0-cargo.rs
+++ b/crates/benchmarks/benches/0-cargo.rs
@@ -98,7 +98,7 @@ mod toml {
     use toml_benchmarks::{manifest, Data, MANIFESTS};
 
     #[divan::bench(args=MANIFESTS)]
-    fn document(sample: &Data<'static>) -> ::toml::Value {
+    fn document(sample: &Data<'static>) -> ::toml::Table {
         sample.content().parse().unwrap()
     }
 


### PR DESCRIPTION
This was rightfully broken by #931