### PR TITLE
fix(toml)!: Allow more types to be used with Map

### DIFF
--- a/crates/serde_spanned/src/spanned.rs
+++ b/crates/serde_spanned/src/spanned.rs
@@ -119,6 +119,12 @@ impl std::borrow::Borrow<str> for Spanned<String> {
     }
 }
 
+impl std::borrow::Borrow<str> for Spanned<std::borrow::Cow<'_, str>> {
+    fn borrow(&self) -> &str {
+        self.get_ref()
+    }
+}
+
 impl<T> AsRef<T> for Spanned<T> {
     fn as_ref(&self) -> &T {
         self.get_ref()

--- a/crates/toml/src/map.rs
+++ b/crates/toml/src/map.rs
@@ -161,6 +161,23 @@ where
         }
     }
 
+    /// Removes a key from the map, returning the stored key and value if the key was previously in the map.
+    #[inline]
+    pub fn remove_entry<Q>(&mut self, key: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Ord + Eq + Hash + ?Sized,
+    {
+        #[cfg(not(feature = "preserve_order"))]
+        {
+            self.map.remove_entry(key)
+        }
+        #[cfg(feature = "preserve_order")]
+        {
+            self.map.shift_remove_entry(key)
+        }
+    }
+
     /// Retains only the elements specified by the `keep` predicate.
     ///
     /// In other words, remove all pairs `(k, v)` for which `keep(&k, &mut v)`

--- a/crates/toml/src/map.rs
+++ b/crates/toml/src/map.rs
@@ -38,7 +38,10 @@ type MapImpl<K, V> = BTreeMap<K, V>;
 #[cfg(feature = "preserve_order")]
 type MapImpl<K, V> = IndexMap<K, V>;
 
-impl Map<String, Value> {
+impl<K, V> Map<K, V>
+where
+    K: Ord + Hash,
+{
     /// Makes a new empty Map.
     #[inline]
     pub fn new() -> Self {
@@ -78,9 +81,9 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
-    pub fn get<Q>(&self, key: &Q) -> Option<&Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
     where
-        String: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Ord + Eq + Hash + ?Sized,
     {
         self.map.get(key)
@@ -93,7 +96,7 @@ impl Map<String, Value> {
     #[inline]
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        String: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Ord + Eq + Hash + ?Sized,
     {
         self.map.contains_key(key)
@@ -104,9 +107,9 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
-    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut Value>
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
-        String: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Ord + Eq + Hash + ?Sized,
     {
         self.map.get_mut(key)
@@ -117,9 +120,9 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
-    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&String, &Value)>
+    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
     where
-        String: Borrow<Q>,
+        K: Borrow<Q>,
         Q: ?Sized + Ord + Eq + Hash,
     {
         self.map.get_key_value(key)
@@ -133,7 +136,7 @@ impl Map<String, Value> {
     /// value is returned. The key is not updated, though; this matters for
     /// types that can be `==` without being identical.
     #[inline]
-    pub fn insert(&mut self, k: String, v: Value) -> Option<Value> {
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         self.map.insert(k, v)
     }
 
@@ -143,9 +146,9 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
-    pub fn remove<Q>(&mut self, key: &Q) -> Option<Value>
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
     where
-        String: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Ord + Eq + Hash + ?Sized,
     {
         #[cfg(not(feature = "preserve_order"))]
@@ -167,16 +170,17 @@ impl Map<String, Value> {
     #[inline]
     pub fn retain<F>(&mut self, mut keep: F)
     where
-        F: FnMut(&str, &mut Value) -> bool,
+        K: AsRef<str>,
+        F: FnMut(&str, &mut V) -> bool,
     {
-        self.map.retain(|key, value| keep(key.as_str(), value));
+        self.map.retain(|key, value| keep(key.as_ref(), value));
     }
 
     /// Gets the given key's corresponding entry in the map for in-place
     /// manipulation.
-    pub fn entry<S>(&mut self, key: S) -> Entry<'_>
+    pub fn entry<S>(&mut self, key: S) -> Entry<'_, K, V>
     where
-        S: Into<String>,
+        S: Into<K>,
     {
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
@@ -203,7 +207,7 @@ impl Map<String, Value> {
 
     /// Gets an iterator over the entries of the map.
     #[inline]
-    pub fn iter(&self) -> Iter<'_> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             iter: self.map.iter(),
         }
@@ -211,7 +215,7 @@ impl Map<String, Value> {
 
     /// Gets a mutable iterator over the entries of the map.
     #[inline]
-    pub fn iter_mut(&mut self) -> IterMut<'_> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut {
             iter: self.map.iter_mut(),
         }
@@ -219,7 +223,7 @@ impl Map<String, Value> {
 
     /// Gets an iterator over the keys of the map.
     #[inline]
-    pub fn keys(&self) -> Keys<'_> {
+    pub fn keys(&self) -> Keys<'_, K, V> {
         Keys {
             iter: self.map.keys(),
         }
@@ -227,14 +231,14 @@ impl Map<String, Value> {
 
     /// Gets an iterator over the values of the map.
     #[inline]
-    pub fn values(&self) -> Values<'_> {
+    pub fn values(&self) -> Values<'_, K, V> {
         Values {
             iter: self.map.values(),
         }
     }
 }
 
-impl Default for Map<String, Value> {
+impl<K, V> Default for Map<K, V> {
     #[inline]
     fn default() -> Self {
         Map {
@@ -243,7 +247,7 @@ impl Default for Map<String, Value> {
     }
 }
 
-impl Clone for Map<String, Value> {
+impl<K: Clone, V: Clone> Clone for Map<K, V> {
     #[inline]
     fn clone(&self) -> Self {
         Map {
@@ -252,7 +256,7 @@ impl Clone for Map<String, Value> {
     }
 }
 
-impl PartialEq for Map<String, Value> {
+impl<K: Eq + Hash, V: PartialEq> PartialEq for Map<K, V> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.map.eq(&other.map)
@@ -261,31 +265,31 @@ impl PartialEq for Map<String, Value> {
 
 /// Access an element of this map. Panics if the given key is not present in the
 /// map.
-impl<Q> ops::Index<&Q> for Map<String, Value>
+impl<K, V, Q> ops::Index<&Q> for Map<K, V>
 where
-    String: Borrow<Q>,
+    K: Borrow<Q> + Ord,
     Q: Ord + Eq + Hash + ?Sized,
 {
-    type Output = Value;
+    type Output = V;
 
-    fn index(&self, index: &Q) -> &Value {
+    fn index(&self, index: &Q) -> &V {
         self.map.index(index)
     }
 }
 
 /// Mutably access an element of this map. Panics if the given key is not
 /// present in the map.
-impl<Q> ops::IndexMut<&Q> for Map<String, Value>
+impl<K, V, Q> ops::IndexMut<&Q> for Map<K, V>
 where
-    String: Borrow<Q>,
+    K: Borrow<Q> + Ord,
     Q: Ord + Eq + Hash + ?Sized,
 {
-    fn index_mut(&mut self, index: &Q) -> &mut Value {
+    fn index_mut(&mut self, index: &Q) -> &mut V {
         self.map.get_mut(index).expect("no entry found for key")
     }
 }
 
-impl Debug for Map<String, Value> {
+impl<K: Debug, V: Debug> Debug for Map<K, V> {
     #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         self.map.fmt(formatter)
@@ -350,10 +354,10 @@ impl<'de> de::Deserialize<'de> for Map<String, Value> {
     }
 }
 
-impl FromIterator<(String, Value)> for Map<String, Value> {
+impl<K: Ord + Hash, V> FromIterator<(K, V)> for Map<K, V> {
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = (String, Value)>,
+        T: IntoIterator<Item = (K, V)>,
     {
         Map {
             map: FromIterator::from_iter(iter),
@@ -361,10 +365,10 @@ impl FromIterator<(String, Value)> for Map<String, Value> {
     }
 }
 
-impl Extend<(String, Value)> for Map<String, Value> {
+impl<K: Ord + Hash, V> Extend<(K, V)> for Map<K, V> {
     fn extend<T>(&mut self, iter: T)
     where
-        T: IntoIterator<Item = (String, Value)>,
+        T: IntoIterator<Item = (K, V)>,
     {
         self.map.extend(iter);
     }
@@ -407,40 +411,40 @@ macro_rules! delegate_iterator {
 ///
 /// [`entry`]: struct.Map.html#method.entry
 /// [`Map`]: struct.Map.html
-pub enum Entry<'a> {
+pub enum Entry<'a, K, V> {
     /// A vacant Entry.
-    Vacant(VacantEntry<'a>),
+    Vacant(VacantEntry<'a, K, V>),
     /// An occupied Entry.
-    Occupied(OccupiedEntry<'a>),
+    Occupied(OccupiedEntry<'a, K, V>),
 }
 
 /// A vacant Entry. It is part of the [`Entry`] enum.
 ///
 /// [`Entry`]: enum.Entry.html
-pub struct VacantEntry<'a> {
-    vacant: VacantEntryImpl<'a>,
+pub struct VacantEntry<'a, K, V> {
+    vacant: VacantEntryImpl<'a, K, V>,
 }
 
 /// An occupied Entry. It is part of the [`Entry`] enum.
 ///
 /// [`Entry`]: enum.Entry.html
-pub struct OccupiedEntry<'a> {
-    occupied: OccupiedEntryImpl<'a>,
+pub struct OccupiedEntry<'a, K, V> {
+    occupied: OccupiedEntryImpl<'a, K, V>,
 }
 
 #[cfg(not(feature = "preserve_order"))]
-type VacantEntryImpl<'a> = btree_map::VacantEntry<'a, String, Value>;
+type VacantEntryImpl<'a, K, V> = btree_map::VacantEntry<'a, K, V>;
 #[cfg(feature = "preserve_order")]
-type VacantEntryImpl<'a> = indexmap::map::VacantEntry<'a, String, Value>;
+type VacantEntryImpl<'a, K, V> = indexmap::map::VacantEntry<'a, K, V>;
 
 #[cfg(not(feature = "preserve_order"))]
-type OccupiedEntryImpl<'a> = btree_map::OccupiedEntry<'a, String, Value>;
+type OccupiedEntryImpl<'a, K, V> = btree_map::OccupiedEntry<'a, K, V>;
 #[cfg(feature = "preserve_order")]
-type OccupiedEntryImpl<'a> = indexmap::map::OccupiedEntry<'a, String, Value>;
+type OccupiedEntryImpl<'a, K, V> = indexmap::map::OccupiedEntry<'a, K, V>;
 
-impl<'a> Entry<'a> {
+impl<'a, K: Ord, V> Entry<'a, K, V> {
     /// Returns a reference to this entry's key.
-    pub fn key(&self) -> &String {
+    pub fn key(&self) -> &K {
         match *self {
             Entry::Vacant(ref e) => e.key(),
             Entry::Occupied(ref e) => e.key(),
@@ -449,7 +453,7 @@ impl<'a> Entry<'a> {
 
     /// Ensures a value is in the entry by inserting the default if empty, and
     /// returns a mutable reference to the value in the entry.
-    pub fn or_insert(self, default: Value) -> &'a mut Value {
+    pub fn or_insert(self, default: V) -> &'a mut V {
         match self {
             Entry::Vacant(entry) => entry.insert(default),
             Entry::Occupied(entry) => entry.into_mut(),
@@ -459,9 +463,9 @@ impl<'a> Entry<'a> {
     /// Ensures a value is in the entry by inserting the result of the default
     /// function if empty, and returns a mutable reference to the value in the
     /// entry.
-    pub fn or_insert_with<F>(self, default: F) -> &'a mut Value
+    pub fn or_insert_with<F>(self, default: F) -> &'a mut V
     where
-        F: FnOnce() -> Value,
+        F: FnOnce() -> V,
     {
         match self {
             Entry::Vacant(entry) => entry.insert(default()),
@@ -470,57 +474,57 @@ impl<'a> Entry<'a> {
     }
 }
 
-impl<'a> VacantEntry<'a> {
+impl<'a, K: Ord, V> VacantEntry<'a, K, V> {
     /// Gets a reference to the key that would be used when inserting a value
     /// through the `VacantEntry`.
     #[inline]
-    pub fn key(&self) -> &String {
+    pub fn key(&self) -> &K {
         self.vacant.key()
     }
 
     /// Sets the value of the entry with the `VacantEntry`'s key, and returns a
     /// mutable reference to it.
     #[inline]
-    pub fn insert(self, value: Value) -> &'a mut Value {
+    pub fn insert(self, value: V) -> &'a mut V {
         self.vacant.insert(value)
     }
 }
 
-impl<'a> OccupiedEntry<'a> {
+impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// Gets a reference to the key in the entry.
     #[inline]
-    pub fn key(&self) -> &String {
+    pub fn key(&self) -> &K {
         self.occupied.key()
     }
 
     /// Gets a reference to the value in the entry.
     #[inline]
-    pub fn get(&self) -> &Value {
+    pub fn get(&self) -> &V {
         self.occupied.get()
     }
 
     /// Gets a mutable reference to the value in the entry.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut Value {
+    pub fn get_mut(&mut self) -> &mut V {
         self.occupied.get_mut()
     }
 
     /// Converts the entry into a mutable reference to its value.
     #[inline]
-    pub fn into_mut(self) -> &'a mut Value {
+    pub fn into_mut(self) -> &'a mut V {
         self.occupied.into_mut()
     }
 
     /// Sets the value of the entry with the `OccupiedEntry`'s key, and returns
     /// the entry's old value.
     #[inline]
-    pub fn insert(&mut self, value: Value) -> Value {
+    pub fn insert(&mut self, value: V) -> V {
         self.occupied.insert(value)
     }
 
     /// Takes the value of the entry out of the map, and returns it.
     #[inline]
-    pub fn remove(self) -> Value {
+    pub fn remove(self) -> V {
         #[cfg(not(feature = "preserve_order"))]
         {
             self.occupied.remove()
@@ -534,9 +538,9 @@ impl<'a> OccupiedEntry<'a> {
 
 //////////////////////////////////////////////////////////////////////////////
 
-impl<'a> IntoIterator for &'a Map<String, Value> {
-    type Item = (&'a String, &'a Value);
-    type IntoIter = Iter<'a>;
+impl<'a, K, V> IntoIterator for &'a Map<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         Iter {
@@ -546,22 +550,22 @@ impl<'a> IntoIterator for &'a Map<String, Value> {
 }
 
 /// An iterator over a `toml::Map`'s entries.
-pub struct Iter<'a> {
-    iter: IterImpl<'a>,
+pub struct Iter<'a, K, V> {
+    iter: IterImpl<'a, K, V>,
 }
 
 #[cfg(not(feature = "preserve_order"))]
-type IterImpl<'a> = btree_map::Iter<'a, String, Value>;
+type IterImpl<'a, K, V> = btree_map::Iter<'a, K, V>;
 #[cfg(feature = "preserve_order")]
-type IterImpl<'a> = indexmap::map::Iter<'a, String, Value>;
+type IterImpl<'a, K, V> = indexmap::map::Iter<'a, K, V>;
 
-delegate_iterator!((Iter<'a>) => (&'a String, &'a Value));
+delegate_iterator!((Iter<'a, K, V>) => (&'a K, &'a V));
 
 //////////////////////////////////////////////////////////////////////////////
 
-impl<'a> IntoIterator for &'a mut Map<String, Value> {
-    type Item = (&'a String, &'a mut Value);
-    type IntoIter = IterMut<'a>;
+impl<'a, K, V> IntoIterator for &'a mut Map<K, V> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         IterMut {
@@ -571,22 +575,22 @@ impl<'a> IntoIterator for &'a mut Map<String, Value> {
 }
 
 /// A mutable iterator over a `toml::Map`'s entries.
-pub struct IterMut<'a> {
-    iter: IterMutImpl<'a>,
+pub struct IterMut<'a, K, V> {
+    iter: IterMutImpl<'a, K, V>,
 }
 
 #[cfg(not(feature = "preserve_order"))]
-type IterMutImpl<'a> = btree_map::IterMut<'a, String, Value>;
+type IterMutImpl<'a, K, V> = btree_map::IterMut<'a, K, V>;
 #[cfg(feature = "preserve_order")]
-type IterMutImpl<'a> = indexmap::map::IterMut<'a, String, Value>;
+type IterMutImpl<'a, K, V> = indexmap::map::IterMut<'a, K, V>;
 
-delegate_iterator!((IterMut<'a>) => (&'a String, &'a mut Value));
+delegate_iterator!((IterMut<'a, K, V>) => (&'a K, &'a mut V));
 
 //////////////////////////////////////////////////////////////////////////////
 
-impl IntoIterator for Map<String, Value> {
-    type Item = (String, Value);
-    type IntoIter = IntoIter;
+impl<K, V> IntoIterator for Map<K, V> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
@@ -596,41 +600,41 @@ impl IntoIterator for Map<String, Value> {
 }
 
 /// An owning iterator over a `toml::Map`'s entries.
-pub struct IntoIter {
-    iter: IntoIterImpl,
+pub struct IntoIter<K, V> {
+    iter: IntoIterImpl<K, V>,
 }
 
 #[cfg(not(feature = "preserve_order"))]
-type IntoIterImpl = btree_map::IntoIter<String, Value>;
+type IntoIterImpl<K, V> = btree_map::IntoIter<K, V>;
 #[cfg(feature = "preserve_order")]
-type IntoIterImpl = indexmap::map::IntoIter<String, Value>;
+type IntoIterImpl<K, V> = indexmap::map::IntoIter<K, V>;
 
-delegate_iterator!((IntoIter) => (String, Value));
+delegate_iterator!((IntoIter<K,V>) => (K, V));
 
 //////////////////////////////////////////////////////////////////////////////
 
 /// An iterator over a `toml::Map`'s keys.
-pub struct Keys<'a> {
-    iter: KeysImpl<'a>,
+pub struct Keys<'a, K, V> {
+    iter: KeysImpl<'a, K, V>,
 }
 
 #[cfg(not(feature = "preserve_order"))]
-type KeysImpl<'a> = btree_map::Keys<'a, String, Value>;
+type KeysImpl<'a, K, V> = btree_map::Keys<'a, K, V>;
 #[cfg(feature = "preserve_order")]
-type KeysImpl<'a> = indexmap::map::Keys<'a, String, Value>;
+type KeysImpl<'a, K, V> = indexmap::map::Keys<'a, K, V>;
 
-delegate_iterator!((Keys<'a>) => &'a String);
+delegate_iterator!((Keys<'a, K, V>) => &'a K);
 
 //////////////////////////////////////////////////////////////////////////////
 
 /// An iterator over a `toml::Map`'s values.
-pub struct Values<'a> {
-    iter: ValuesImpl<'a>,
+pub struct Values<'a, K, V> {
+    iter: ValuesImpl<'a, K, V>,
 }
 
 #[cfg(not(feature = "preserve_order"))]
-type ValuesImpl<'a> = btree_map::Values<'a, String, Value>;
+type ValuesImpl<'a, K, V> = btree_map::Values<'a, K, V>;
 #[cfg(feature = "preserve_order")]
-type ValuesImpl<'a> = indexmap::map::Values<'a, String, Value>;
+type ValuesImpl<'a, K, V> = indexmap::map::Values<'a, K, V>;
 
-delegate_iterator!((Values<'a>) => &'a Value);
+delegate_iterator!((Values<'a, K, V>) => &'a V);

--- a/crates/toml_edit/src/parser/document.rs
+++ b/crates/toml_edit/src/parser/document.rs
@@ -465,21 +465,6 @@ fn descend_path<'t>(
             }
             crate::Entry::Occupied(entry) => {
                 match entry.into_mut() {
-                    Item::Value(ref existing) => {
-                        let old_span = existing.span().expect("all items have spans");
-                        let old_span =
-                            toml_parse::Span::new_unchecked(old_span.start, old_span.end);
-                        let key_span = get_key_span(key).expect("all keys have spans");
-                        errors.report_error(
-                            ParseError::new(format!(
-                                "cannot extend value of type {} with a dotted key",
-                                existing.type_name()
-                            ))
-                            .with_unexpected(key_span)
-                            .with_context(old_span),
-                        );
-                        return None;
-                    }
                     Item::ArrayOfTables(ref mut array) => {
                         debug_assert!(!array.is_empty());
 
@@ -500,6 +485,21 @@ fn descend_path<'t>(
                             return None;
                         }
                         sweet_child_of_mine
+                    }
+                    Item::Value(ref existing) => {
+                        let old_span = existing.span().expect("all items have spans");
+                        let old_span =
+                            toml_parse::Span::new_unchecked(old_span.start, old_span.end);
+                        let key_span = get_key_span(key).expect("all keys have spans");
+                        errors.report_error(
+                            ParseError::new(format!(
+                                "cannot extend value of type {} with a dotted key",
+                                existing.type_name()
+                            ))
+                            .with_unexpected(key_span)
+                            .with_context(old_span),
+                        );
+                        return None;
                     }
                     Item::None => unreachable!(),
                 }


### PR DESCRIPTION
This in general is prep for `toml`s new parser