### PR TITLE
perf(toml): Allow opting in to faster hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +930,7 @@ version = "0.8.23"
 dependencies = [
  "anstream 0.6.18",
  "anstyle",
+ "foldhash",
  "indexmap 2.3.0",
  "itertools",
  "serde",

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 simd = ["toml_parse/simd"]
 unsafe = ["toml_parse/unsafe", "toml_edit/unsafe"]
 preserve_order = ["toml_old/preserve_order", "toml/preserve_order"]
+fast_hash = ["toml/fast_hash"]
 
 [dependencies]
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/toml/Cargo.toml
+++ b/crates/toml/Cargo.toml
@@ -33,6 +33,7 @@ std = ["indexmap?/std"]
 parse = ["dep:toml_parse", "dep:winnow"]
 display = ["std", "dep:toml_edit", "toml_edit?/display"]
 unsafe = ["toml_parse?/unsafe"]
+fast_hash = ["preserve_order", "dep:foldhash"]
 debug = ["std", "toml_parse?/debug", "dep:anstream", "dep:anstyle"]
 
 # Provide a method disable_recursion_limit to parse arbitrarily deep structures
@@ -57,6 +58,7 @@ anstyle = { version = "1.0.8", optional = true }
 toml_edit = { version = "0.22.27", path = "../toml_edit", default-features = false, features = ["serde"], optional = true }
 toml_datetime = { version = "0.6.11", path = "../toml_datetime", default-features = false, features = ["serde", "alloc"] }
 serde_spanned = { version = "0.6.9", path = "../serde_spanned", default-features = false, features = ["serde", "alloc"] }
+foldhash = { version = "0.1.5", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.199", features = ["derive"] }


### PR DESCRIPTION
I chose `foldhash` because it is the default of `hashbrown@0.15` (replacing ahash), see rust-lang/hashbrown#563.

Currently, `ahash` is the only hasher I noticed inside of Cargo and that is coming in from `hashbrown@0.14`.

In the future, we could consider allowing the use of a `FixedState` so we could offer `IndexMap` on `alloc`.

```
$ cargo bench --bench 0-cargo -Fpreserve_order -- 0_cargo::toml::document::2-features
   Compiling toml v0.5.11
   Compiling toml v0.8.23 (/home/epage/src/personal/toml/crates/toml)
   Compiling toml_benchmarks v0.0.0 (/home/epage/src/personal/toml/crates/benchmarks)
    Finished `bench` profile [optimized] target(s) in 19.13s
     Running benches/0-cargo.rs (/home/epage/src/personal/toml/target/release/deps/0_cargo-09d7e00849b1b878)
Timer precision: 11 ns
0_cargo              fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ toml                            │               │               │               │         │
   ╰─ document                     │               │               │               │         │
      ╰─ 2-features  468.8 µs      │ 1.016 ms      │ 513.5 µs      │ 543.5 µs      │ 100     │ 100


$ cargo bench --bench 0-cargo -Ffast_hash -- 0_cargo::toml::document::2-features
    Finished `bench` profile [optimized] target(s) in 0.02s
     Running benches/0-cargo.rs (/home/epage/src/personal/toml/target/release/deps/0_cargo-ea11bd9a52599c35)
Timer precision: 18 ns
0_cargo              fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ toml                            │               │               │               │         │
   ╰─ document                     │               │               │               │         │
      ╰─ 2-features  431.4 µs      │ 870.3 µs      │ 446.2 µs      │ 459.9 µs      │ 100     │ 100
```