### PR TITLE
perf(toml): Don't recreate tables for make_owned 

### DIFF
--- a/crates/toml/src/de/detable.rs
+++ b/crates/toml/src/de/detable.rs
@@ -38,18 +38,11 @@ impl<'i> DeTable<'i> {
 
     /// Ensure no data is borrowed
     pub fn make_owned(&mut self) {
-        let borrowed = core::mem::take(self);
-        let owned = borrowed
-            .into_iter()
-            .map(|(k, mut v)| {
-                let span = k.span();
-                let inner = k.into_inner();
-                let inner = Cow::Owned(inner.into_owned());
-                let k = Spanned::new(span, inner);
-                v.get_mut().make_owned();
-                (k, v)
-            })
-            .collect::<Self>();
-        *self = owned;
+        self.retain2(|k, v| {
+            let owned = core::mem::take(k.get_mut());
+            *k.get_mut() = Cow::Owned(owned.into_owned());
+            v.get_mut().make_owned();
+            true
+        });
     }
 }

--- a/crates/toml/src/map.rs
+++ b/crates/toml/src/map.rs
@@ -269,6 +269,29 @@ where
             iter: self.map.values(),
         }
     }
+
+    /// Scan through each key-value pair in the map and keep those where the
+    /// closure `keep` returns `true`.
+    ///
+    /// The elements are visited in order, and remaining elements keep their
+    /// order.
+    ///
+    /// Computes in **O(n)** time (average).
+    pub(crate) fn retain2<F>(&mut self, mut keep: F)
+    where
+        F: FnMut(&mut K, &mut V) -> bool,
+    {
+        self.map = core::mem::take(&mut self.map)
+            .into_iter()
+            .flat_map(move |(mut k, mut v)| {
+                if keep(&mut k, &mut v) {
+                    Some((k, v))
+                } else {
+                    None
+                }
+            })
+            .collect();
+    }
 }
 
 impl<K, V> Map<K, V>

--- a/crates/toml/src/map.rs
+++ b/crates/toml/src/map.rs
@@ -277,20 +277,29 @@ where
     /// order.
     ///
     /// Computes in **O(n)** time (average).
+    #[allow(unused_mut)]
     pub(crate) fn retain2<F>(&mut self, mut keep: F)
     where
         F: FnMut(&mut K, &mut V) -> bool,
     {
-        self.map = core::mem::take(&mut self.map)
-            .into_iter()
-            .flat_map(move |(mut k, mut v)| {
-                if keep(&mut k, &mut v) {
-                    Some((k, v))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        #[cfg(feature = "preserve_order")]
+        {
+            use indexmap::map::MutableKeys as _;
+            self.map.retain2(keep);
+        }
+        #[cfg(not(feature = "preserve_order"))]
+        {
+            self.map = core::mem::take(&mut self.map)
+                .into_iter()
+                .flat_map(move |(mut k, mut v)| {
+                    if keep(&mut k, &mut v) {
+                        Some((k, v))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+        }
     }
 }
 


### PR DESCRIPTION


Before
```console
$ cargo bench --bench 0-cargo -Ffast_hash -- 0_cargo::toml::detable_owned::2-features
    Finished `bench` profile [optimized] target(s) in 0.02s
     Running benches/0-cargo.rs (/home/epage/src/personal/toml/target/release/deps/0_cargo-ea11bd9a52599c35)
Timer precision: 13 ns
0_cargo              fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ toml                            │               │               │               │         │
   ╰─ detable_owned                │               │               │               │         │
      ╰─ 2-features  334.4 µs      │ 724.1 µs      │ 351.8 µs      │ 359.9 µs      │ 100     │ 100
```
After refactor
```console
$ cargo bench --bench 0-cargo -Ffast_hash -- 0_cargo::toml::detable_owned::2-features
    Finished `bench` profile [optimized] target(s) in 0.02s
     Running benches/0-cargo.rs (/home/epage/src/personal/toml/target/release/deps/0_cargo-ea11bd9a52599c35)
Timer precision: 11 ns
0_cargo              fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ toml                            │               │               │               │         │
   ╰─ detable_owned                │               │               │               │         │
      ╰─ 2-features  353.8 µs      │ 1.108 ms      │ 397.8 µs      │ 431.1 µs      │ 100     │ 100
```
After perf work
```console
$ cargo bench --bench 0-cargo -Ffast_hash -- 0_cargo::toml::detable_owned::2-features
   Compiling toml v0.8.23 (/home/epage/src/personal/toml/crates/toml)
   Compiling toml_benchmarks v0.0.0 (/home/epage/src/personal/toml/crates/benchmarks)
    Finished `bench` profile [optimized] target(s) in 19.01s
     Running benches/0-cargo.rs (/home/epage/src/personal/toml/target/release/deps/0_cargo-ea11bd9a52599c35)
Timer precision: 11 ns
0_cargo              fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ toml                            │               │               │               │         │
   ╰─ detable_owned                │               │               │               │         │
      ╰─ 2-features  305.1 µs      │ 670.4 µs      │ 326.9 µs      │ 334.7 µs      │ 100     │ 100
```

As a point of comparison
```console
$ cargo bench --bench 0-cargo -Ffast_hash -- 0_cargo::toml::detable::2-features
    Finished `bench` profile [optimized] target(s) in 0.02s
     Running benches/0-cargo.rs (/home/epage/src/personal/toml/target/release/deps/0_cargo-ea11bd9a52599c35)
Timer precision: 17 ns
0_cargo              fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ toml                            │               │               │               │         │
   ╰─ detable                      │               │               │               │         │
      ╰─ 2-features  265.8 µs      │ 651 µs        │ 288.9 µs      │ 294.1 µs      │ 100     │ 100
```