### PR TITLE
WIP: fix(toml): Switch to custom Cow for DeString

### DIFF
--- a/crates/toml/src/de/parser/detable.rs
+++ b/crates/toml/src/de/parser/detable.rs
@@ -1,5 +1,3 @@
-use alloc::borrow::Cow;
-
 use serde_spanned::Spanned;
 
 use crate::alloc_prelude::*;
@@ -39,8 +37,7 @@ impl<'i> DeTable<'i> {
     /// Ensure no data is borrowed
     pub fn make_owned(&mut self) {
         self.mut_entries(|k, v| {
-            let owned = core::mem::take(k.get_mut());
-            *k.get_mut() = Cow::Owned(owned.into_owned());
+            k.get_mut().make_owned();
             v.get_mut().make_owned();
         });
     }

--- a/crates/toml/src/de/parser/key.rs
+++ b/crates/toml/src/de/parser/key.rs
@@ -115,7 +115,7 @@ impl State {
         let mut decoded = alloc::borrow::Cow::Borrowed("");
         raw.decode_key(&mut decoded, errors);
 
-        let key = Spanned::new(key_span, decoded);
+        let key = Spanned::new(key_span, decoded.into());
         if let Some(last_key) = result_key.replace(key) {
             result_path.push(last_key);
         }

--- a/crates/toml/src/de/parser/value.rs
+++ b/crates/toml/src/de/parser/value.rs
@@ -76,7 +76,7 @@ pub(crate) fn on_scalar<'i>(
     let kind = raw.decode_scalar(&mut decoded, errors);
     match kind {
         toml_parse::decoder::ScalarKind::String => {
-            Spanned::new(value_span, DeValue::String(decoded))
+            Spanned::new(value_span, DeValue::String(decoded.into()))
         }
         toml_parse::decoder::ScalarKind::Boolean(value) => {
             Spanned::new(value_span, DeValue::Boolean(value))
@@ -97,13 +97,16 @@ pub(crate) fn on_scalar<'i>(
             };
             Spanned::new(value_span, DeValue::Datetime(value))
         }
-        toml_parse::decoder::ScalarKind::Float => {
-            Spanned::new(value_span, DeValue::Float(DeFloat { inner: decoded }))
-        }
+        toml_parse::decoder::ScalarKind::Float => Spanned::new(
+            value_span,
+            DeValue::Float(DeFloat {
+                inner: decoded.into(),
+            }),
+        ),
         toml_parse::decoder::ScalarKind::Integer(radix) => Spanned::new(
             value_span,
             DeValue::Integer(DeInteger {
-                inner: decoded,
+                inner: decoded.into(),
                 radix: radix.value(),
             }),
         ),


### PR DESCRIPTION
The goal is to allow us to use `Box<str>` instead of `String`, hoping to improve Cargo having a lot of `DeTable::make_owned`s around.

Unfortunately, we ran into a problem with implementing `Borrow` for `Spanned<DeString>` because
- A blanket impl exists for `Borrow` so `serde_spanned` can't provide one
- `serde_spanned` can't provide one for `DeString` since it doesn't know it exists
- `toml` can't provide one because `Spanned<DeString>` is considered a foreign type