### PR TITLE
fix(spanned): Only consider struct name, not fields, for Spanned

### DIFF
--- a/crates/serde_spanned/src/de.rs
+++ b/crates/serde_spanned/src/de.rs
@@ -6,8 +6,8 @@ use serde::de::IntoDeserializer as _;
 use crate::Spanned;
 
 /// Check if deserializing a [`Spanned`]
-pub fn is_spanned(name: &'static str, fields: &'static [&'static str]) -> bool {
-    crate::spanned::is_spanned(name, fields)
+pub fn is_spanned(name: &'static str) -> bool {
+    crate::spanned::is_spanned(name)
 }
 
 /// Deserializer / format support for emitting [`Spanned`]

--- a/crates/serde_spanned/src/spanned.rs
+++ b/crates/serde_spanned/src/spanned.rs
@@ -16,8 +16,8 @@ pub(crate) const END_FIELD: &str = "$__serde_spanned_private_end";
 #[cfg(feature = "serde")]
 pub(crate) const VALUE_FIELD: &str = "$__serde_spanned_private_value";
 #[cfg(feature = "serde")]
-pub(crate) fn is_spanned(name: &'static str, fields: &'static [&'static str]) -> bool {
-    name == NAME && fields == [START_FIELD, END_FIELD, VALUE_FIELD]
+pub(crate) fn is_spanned(name: &'static str) -> bool {
+    name == NAME
 }
 
 /// A spanned value, indicating the range at which it is defined in the source.

--- a/crates/toml/src/de/deserializer/array.rs
+++ b/crates/toml/src/de/deserializer/array.rs
@@ -28,13 +28,13 @@ impl<'de> serde::Deserializer<'de> for ArrayDeserializer<'de> {
     fn deserialize_struct<V>(
         self,
         name: &'static str,
-        fields: &'static [&'static str],
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        if serde_spanned::de::is_spanned(name, fields) {
+        if serde_spanned::de::is_spanned(name) {
             if let Some(span) = self.span.clone() {
                 return visitor.visit_map(super::SpannedDeserializer::new(self, span));
             } else {

--- a/crates/toml/src/de/deserializer/key.rs
+++ b/crates/toml/src/de/deserializer/key.rs
@@ -49,13 +49,13 @@ impl<'de> serde::de::Deserializer<'de> for KeyDeserializer<'de> {
     fn deserialize_struct<V>(
         self,
         name: &'static str,
-        fields: &'static [&'static str],
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        if serde_spanned::de::is_spanned(name, fields) {
+        if serde_spanned::de::is_spanned(name) {
             if let Some(span) = self.span.clone() {
                 return visitor.visit_map(super::SpannedDeserializer::new(self.key, span));
             } else {

--- a/crates/toml/src/de/deserializer/table.rs
+++ b/crates/toml/src/de/deserializer/table.rs
@@ -51,13 +51,13 @@ impl<'de> serde::Deserializer<'de> for TableDeserializer<'de> {
     fn deserialize_struct<V>(
         self,
         name: &'static str,
-        fields: &'static [&'static str],
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        if serde_spanned::de::is_spanned(name, fields) {
+        if serde_spanned::de::is_spanned(name) {
             if let Some(span) = self.span.clone() {
                 return visitor.visit_map(super::SpannedDeserializer::new(self, span));
             } else {

--- a/crates/toml/src/de/deserializer/value.rs
+++ b/crates/toml/src/de/deserializer/value.rs
@@ -182,7 +182,7 @@ impl<'de> serde::Deserializer<'de> for ValueDeserializer<'de> {
     where
         V: serde::de::Visitor<'de>,
     {
-        if serde_spanned::de::is_spanned(name, fields) {
+        if serde_spanned::de::is_spanned(name) {
             if let Some(span) = self.span.clone() {
                 return visitor.visit_map(super::SpannedDeserializer::new(self, span));
             } else {

--- a/crates/toml_edit/src/de/array.rs
+++ b/crates/toml_edit/src/de/array.rs
@@ -24,13 +24,13 @@ impl<'de> serde::Deserializer<'de> for ArrayDeserializer {
     fn deserialize_struct<V>(
         self,
         name: &'static str,
-        fields: &'static [&'static str],
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        if serde_spanned::de::is_spanned(name, fields) {
+        if serde_spanned::de::is_spanned(name) {
             if let Some(span) = self.span.clone() {
                 return visitor.visit_map(
                     serde_spanned::de::SpannedDeserializer::<Self, Error>::new(self, span),

--- a/crates/toml_edit/src/de/key.rs
+++ b/crates/toml_edit/src/de/key.rs
@@ -48,13 +48,13 @@ impl<'de> serde::de::Deserializer<'de> for KeyDeserializer {
     fn deserialize_struct<V>(
         self,
         name: &'static str,
-        fields: &'static [&'static str],
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        if serde_spanned::de::is_spanned(name, fields) {
+        if serde_spanned::de::is_spanned(name) {
             if let Some(span) = self.span.clone() {
                 return visitor.visit_map(
                     serde_spanned::de::SpannedDeserializer::<&str, Error>::new(

--- a/crates/toml_edit/src/de/table.rs
+++ b/crates/toml_edit/src/de/table.rs
@@ -49,13 +49,13 @@ impl<'de> serde::Deserializer<'de> for TableDeserializer {
     fn deserialize_struct<V>(
         self,
         name: &'static str,
-        fields: &'static [&'static str],
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        if serde_spanned::de::is_spanned(name, fields) {
+        if serde_spanned::de::is_spanned(name) {
             if let Some(span) = self.span.clone() {
                 return visitor.visit_map(
                     serde_spanned::de::SpannedDeserializer::<Self, Error>::new(self, span),

--- a/crates/toml_edit/src/de/value.rs
+++ b/crates/toml_edit/src/de/value.rs
@@ -136,7 +136,7 @@ impl<'de> serde::Deserializer<'de> for ValueDeserializer {
     where
         V: serde::de::Visitor<'de>,
     {
-        if serde_spanned::de::is_spanned(name, fields) {
+        if serde_spanned::de::is_spanned(name) {
             if let Some(span) = self.input.span() {
                 return visitor.visit_map(
                     serde_spanned::de::SpannedDeserializer::<Self, Error>::new(self, span),


### PR DESCRIPTION
This offers us flexibility in what we serialize from and tries to improve error reporting if things evolve