### PR TITLE
Revert "fix(edit)!: Require a Document to always be a Table"

### DIFF
--- a/crates/toml_edit/src/document.rs
+++ b/crates/toml_edit/src/document.rs
@@ -49,6 +49,16 @@ impl<S: AsRef<str>> Document<S> {
 }
 
 impl<S> Document<S> {
+    /// Returns a reference to the root item.
+    pub fn as_item(&self) -> &Item {
+        &self.root
+    }
+
+    /// Returns the root item.
+    pub fn into_item(self) -> Item {
+        self.root
+    }
+
     /// Returns a reference to the root table.
     pub fn as_table(&self) -> &Table {
         self.root.as_table().expect("root should always be a table")
@@ -130,6 +140,21 @@ impl DocumentMut {
     /// Creates an empty document
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Returns a reference to the root item.
+    pub fn as_item(&self) -> &Item {
+        &self.root
+    }
+
+    /// Returns a mutable reference to the root item.
+    pub fn as_item_mut(&mut self) -> &mut Item {
+        &mut self.root
+    }
+
+    /// Returns the root item.
+    pub fn into_item(self) -> Item {
+        self.root
     }
 
     /// Returns a reference to the root table.


### PR DESCRIPTION
This reverts commit 1e410d530a26616fe1e85950ad1edb7da1cc074b.

In trying to update Cargo this, I found it too painful to get to work.

CC #930, #697