### PR TITLE
Avoid some infinite loops with 0.9

### DIFF
--- a/crates/toml/tests/fixtures/invalid/not-toml/deb-like.toml
+++ b/crates/toml/tests/fixtures/invalid/not-toml/deb-like.toml
@@ -1,0 +1,6 @@
+Package: R6
+Version: 2.5.1
+Depends: R (>= 3.0)
+Suggests: testthat, pryr
+NeedsCompilation: no
+License: MIT + file LICENSE

--- a/crates/toml/tests/snapshots/invalid/not-toml/deb-like.stderr
+++ b/crates/toml/tests/snapshots/invalid/not-toml/deb-like.stderr
@@ -1,0 +1,26 @@
+TOML parse error at line 1, column 10
+  |
+1 | Package: R6
+  |          ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 2, column 10
+  |
+2 | Version: 2.5.1
+  |          ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 3, column 10
+  |
+3 | Depends: R (>= 3.0)
+  |          ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 1, column 8
+  |
+1 | Package: R6
+  |        ^
+invalid unquoted key, expected letters, numbers, `-`, `_`


### PR DESCRIPTION
I found this bug while trying to upgrade a tool to 0.9.
This is more a bug report with a hacky fix but I wanted to see what it would take the make the test pass. 
Feel free to only take the test, I didn't want to really dig into the lexer/parser itself