### PR TITLE
fix(lex): Don't loop over ')' for forever

### DIFF
--- a/crates/toml/tests/fixtures/invalid/ext/not-toml/deb.toml
+++ b/crates/toml/tests/fixtures/invalid/ext/not-toml/deb.toml
@@ -1,0 +1,6 @@
+Package: R6
+Version: 2.5.1
+Depends: R (>= 3.0)
+Suggests: testthat, pryr
+NeedsCompilation: no
+License: MIT + file LICENSE

--- a/crates/toml/tests/snapshots/invalid/ext/not-toml/deb.stderr
+++ b/crates/toml/tests/snapshots/invalid/ext/not-toml/deb.stderr
@@ -1,0 +1,47 @@
+TOML parse error at line 1, column 10
+  |
+1 | Package: R6
+  |          ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 2, column 10
+  |
+2 | Version: 2.5.1
+  |          ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 3, column 10
+  |
+3 | Depends: R (>= 3.0)
+  |          ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 4, column 11
+  |
+4 | Suggests: testthat, pryr
+  |           ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 5, column 19
+  |
+5 | NeedsCompilation: no
+  |                   ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 6, column 10
+  |
+6 | License: MIT + file LICENSE
+  |          ^
+key with no value, expected `=`
+
+---
+TOML parse error at line 1, column 8
+  |
+1 | Package: R6
+  |        ^
+invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml_edit/tests/fixtures/invalid/ext/not-toml/deb.toml
+++ b/crates/toml_edit/tests/fixtures/invalid/ext/not-toml/deb.toml
@@ -1,0 +1,6 @@
+Package: R6
+Version: 2.5.1
+Depends: R (>= 3.0)
+Suggests: testthat, pryr
+NeedsCompilation: no
+License: MIT + file LICENSE

--- a/crates/toml_edit/tests/snapshots/invalid/ext/not-toml/deb.stderr
+++ b/crates/toml_edit/tests/snapshots/invalid/ext/not-toml/deb.stderr
@@ -1,0 +1,5 @@
+TOML parse error at line 1, column 10
+  |
+1 | Package: R6
+  |          ^
+key with no value, expected `=`

--- a/crates/toml_parser/src/lexer/mod.rs
+++ b/crates/toml_parser/src/lexer/mod.rs
@@ -608,7 +608,7 @@ pub(crate) const ML_BASIC_STRING_DELIM: &str = "\"\"\"";
 fn lex_atom(stream: &mut Stream<'_>) -> Token {
     let start = stream.current_token_start();
 
-    const TOKEN_START: &[u8] = b".=,[]{} \t#\r\n)'\"";
+    const TOKEN_START: &[u8] = b".=,[]{} \t#\r\n'\"";
     let offset = stream
         .as_bstr()
         .offset_for(|b| TOKEN_START.contains_token(b))


### PR DESCRIPTION
A ')' was accidentally added to the list of token start characters, so if we saw one, `lex_atom` wouldn't eat it and nothing else would, so we'd get stuck in an infinite loop.

Fixes #1002