### PR TITLE
feat(writer): Implement TomlInteger

### DIFF
--- a/crates/toml_writer/src/integer.rs
+++ b/crates/toml_writer/src/integer.rs
@@ -1,0 +1,194 @@
+use core::fmt::{self, Display};
+
+/// N must be an integer type.
+#[derive(Copy, Clone, Debug)]
+pub struct TomlInteger<N> {
+    value: N,
+    radix: Radix,
+}
+
+impl crate::WriteTomlValue for TomlInteger<u8> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<i8> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<u16> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<i16> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<u32> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<i32> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<u64> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<i64> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<u128> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<i128> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<usize> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+impl crate::WriteTomlValue for TomlInteger<isize> {
+    fn write_toml_value<W: crate::TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_toml_value(self.value, &self.radix, writer)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct TomlIntegerFormat {
+    radix: Radix,
+    _separators: (), // Placeholder for future use
+}
+
+impl TomlIntegerFormat {
+    pub fn new() -> Self {
+        Self {
+            radix: Radix::Decimal,
+            _separators: (),
+        }
+    }
+
+    pub fn as_decimal(self) -> Self {
+        Self {
+            radix: Radix::Decimal,
+            ..self
+        }
+    }
+
+    pub fn as_hex_upper(self) -> Self {
+        Self {
+            radix: Radix::Hexadecimal {
+                case: HexCase::Upper,
+            },
+            ..self
+        }
+    }
+
+    pub fn as_hex_lower(self) -> Self {
+        Self {
+            radix: Radix::Hexadecimal {
+                case: HexCase::Lower,
+            },
+            ..self
+        }
+    }
+
+    pub fn as_octal(self) -> Self {
+        Self {
+            radix: Radix::Octal,
+            ..self
+        }
+    }
+
+    pub fn as_binary(self) -> Self {
+        Self {
+            radix: Radix::Binary,
+            ..self
+        }
+    }
+
+    /// Returns `None` if the value is negative and the radix is not decimal.
+    pub fn format<N: PartialOrd<i32>>(self, value: N) -> Option<TomlInteger<N>>
+    where
+        TomlInteger<N>: crate::WriteTomlValue,
+    {
+        match self.radix {
+            Radix::Decimal => (),
+            Radix::Hexadecimal { .. } | Radix::Octal | Radix::Binary => {
+                if value < 0 {
+                    return None;
+                }
+            }
+        }
+
+        Some(TomlInteger {
+            value,
+            radix: self.radix,
+        })
+    }
+}
+
+impl Default for TomlIntegerFormat {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum Radix {
+    Decimal,
+    Hexadecimal { case: HexCase },
+    Octal,
+    Binary,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum HexCase {
+    Upper,
+    Lower,
+}
+
+fn write_toml_value<
+    N: Display + fmt::UpperHex + fmt::LowerHex + fmt::Octal + fmt::Binary,
+    W: crate::TomlWrite + ?Sized,
+>(
+    value: N,
+    radix: &Radix,
+    writer: &mut W,
+) -> fmt::Result {
+    match radix {
+        Radix::Decimal => write!(writer, "{value}")?,
+        Radix::Hexadecimal { case } => match case {
+            HexCase::Upper => write!(writer, "0x{value:X}")?,
+            HexCase::Lower => write!(writer, "0x{value:x}")?,
+        },
+        Radix::Octal => write!(writer, "0o{value:o}")?,
+        Radix::Binary => write!(writer, "0b{value:b}")?,
+    }
+    Ok(())
+}

--- a/crates/toml_writer/src/lib.rs
+++ b/crates/toml_writer/src/lib.rs
@@ -59,11 +59,14 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+mod integer;
 mod key;
 mod string;
 mod value;
 mod write;
 
+pub use integer::TomlInteger;
+pub use integer::TomlIntegerFormat;
 #[cfg(feature = "alloc")]
 pub use key::ToTomlKey;
 pub use key::WriteTomlKey;

--- a/crates/toml_writer/tests/integer.rs
+++ b/crates/toml_writer/tests/integer.rs
@@ -1,0 +1,92 @@
+use toml_writer::ToTomlValue;
+use toml_writer::TomlIntegerFormat;
+
+#[test]
+fn positive() {
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .format(42)
+            .map(|i| i.to_toml_value()),
+        Some(String::from("42"))
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_decimal()
+            .format(42)
+            .map(|i| i.to_toml_value()),
+        Some(String::from("42"))
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_hex_upper()
+            .format(42)
+            .map(|i| i.to_toml_value()),
+        Some(String::from("0x2A"))
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_hex_lower()
+            .format(42)
+            .map(|i| i.to_toml_value()),
+        Some(String::from("0x2a"))
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_octal()
+            .format(42)
+            .map(|i| i.to_toml_value()),
+        Some(String::from("0o52"))
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_binary()
+            .format(42)
+            .map(|i| i.to_toml_value()),
+        Some(String::from("0b101010"))
+    );
+}
+
+#[test]
+fn negative() {
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .format(-42)
+            .map(|i| i.to_toml_value()),
+        Some(String::from("-42"))
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_decimal()
+            .format(-42)
+            .map(|i| i.to_toml_value()),
+        Some(String::from("-42"))
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_hex_upper()
+            .format(-42)
+            .map(|i| i.to_toml_value()),
+        None
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_hex_lower()
+            .format(-42)
+            .map(|i| i.to_toml_value()),
+        None
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_octal()
+            .format(-42)
+            .map(|i| i.to_toml_value()),
+        None
+    );
+    assert_eq!(
+        TomlIntegerFormat::new()
+            .as_binary()
+            .format(-42)
+            .map(|i| i.to_toml_value()),
+        None
+    );
+}


### PR DESCRIPTION
Implements `TomlInteger` and `TomlIntegerFormat` following the discussion at #812. This supersedes #837.