### PR TITLE
`ImDocument` hyperlink in `span()` should now point to `Document`

### DIFF
--- a/crates/toml_edit/src/array.rs
+++ b/crates/toml_edit/src/array.rs
@@ -88,7 +88,7 @@ impl Array {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.span.clone()
     }

--- a/crates/toml_edit/src/array.rs
+++ b/crates/toml_edit/src/array.rs
@@ -88,7 +88,7 @@ impl Array {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.span.clone()
     }

--- a/crates/toml_edit/src/array_of_tables.rs
+++ b/crates/toml_edit/src/array_of_tables.rs
@@ -34,7 +34,7 @@ impl ArrayOfTables {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.span.clone()
     }

--- a/crates/toml_edit/src/array_of_tables.rs
+++ b/crates/toml_edit/src/array_of_tables.rs
@@ -34,7 +34,7 @@ impl ArrayOfTables {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.span.clone()
     }

--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -221,7 +221,7 @@ impl InlineTable {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.span.clone()
     }

--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -221,7 +221,7 @@ impl InlineTable {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.span.clone()
     }

--- a/crates/toml_edit/src/item.rs
+++ b/crates/toml_edit/src/item.rs
@@ -323,7 +323,7 @@ impl Item {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         match self {
             Self::None => None,

--- a/crates/toml_edit/src/item.rs
+++ b/crates/toml_edit/src/item.rs
@@ -323,7 +323,7 @@ impl Item {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         match self {
             Self::None => None,

--- a/crates/toml_edit/src/key.rs
+++ b/crates/toml_edit/src/key.rs
@@ -130,7 +130,7 @@ impl Key {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.repr.as_ref().and_then(|r| r.span())
     }

--- a/crates/toml_edit/src/key.rs
+++ b/crates/toml_edit/src/key.rs
@@ -130,7 +130,7 @@ impl Key {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.repr.as_ref().and_then(|r| r.span())
     }

--- a/crates/toml_edit/src/raw_string.rs
+++ b/crates/toml_edit/src/raw_string.rs
@@ -27,7 +27,7 @@ impl RawString {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         match &self.0 {
             RawStringInner::Empty => None,

--- a/crates/toml_edit/src/raw_string.rs
+++ b/crates/toml_edit/src/raw_string.rs
@@ -27,7 +27,7 @@ impl RawString {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         match &self.0 {
             RawStringInner::Empty => None,

--- a/crates/toml_edit/src/repr.rs
+++ b/crates/toml_edit/src/repr.rs
@@ -63,7 +63,7 @@ where
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.repr.as_ref().and_then(|r| r.span())
     }
@@ -155,7 +155,7 @@ impl Repr {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.raw_value.span()
     }

--- a/crates/toml_edit/src/repr.rs
+++ b/crates/toml_edit/src/repr.rs
@@ -63,7 +63,7 @@ where
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.repr.as_ref().and_then(|r| r.span())
     }
@@ -155,7 +155,7 @@ impl Repr {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.raw_value.span()
     }

--- a/crates/toml_edit/src/value.rs
+++ b/crates/toml_edit/src/value.rs
@@ -209,7 +209,7 @@ impl Value {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`Document`][crate::Document].
+    /// This generally requires a [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         match self {
             Self::String(f) => f.span(),

--- a/crates/toml_edit/src/value.rs
+++ b/crates/toml_edit/src/value.rs
@@ -209,7 +209,7 @@ impl Value {
 
     /// The location within the original document
     ///
-    /// This generally requires an [`ImDocument`][crate::ImDocument].
+    /// This generally requires an [`Document`][crate::Document].
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         match self {
             Self::String(f) => f.span(),


### PR DESCRIPTION
Hi, I glanced at the documentation and noticed that the `span()` function's docs were mentioning the now deprecated `ImDocument` instead of it's replacement struct  `Document`, so I went ahead and quickly corrected that.

Kind regards