### PR TITLE
fix(toml): Don't enable std in toml_writer

### DIFF
--- a/crates/toml/Cargo.toml
+++ b/crates/toml/Cargo.toml
@@ -56,7 +56,7 @@ winnow = { version = "0.7.10", default-features = false, optional = true }
 anstream = { version = "0.6.15", optional = true }
 anstyle = { version = "1.0.8", optional = true }
 toml_datetime = { version = "0.7.0", path = "../toml_datetime", default-features = false, features = ["alloc"] }
-toml_writer = { version = "1.0.2", path = "../toml_writer", optional = true }
+toml_writer = { version = "1.0.2", path = "../toml_writer", default-features = false, features = ["alloc"], optional = true }
 serde_spanned = { version = "1.0.0", path = "../serde_spanned", default-features = false, features = ["alloc"] }
 foldhash = { version = "0.1.5", default-features = false, optional = true }
 


### PR DESCRIPTION
Found when looking at #1018