### PR TITLE
feat(edit): Expose Table::span

### DIFF
--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -273,8 +273,10 @@ impl Table {
             .map(|(_, key, _)| key.as_mut())
     }
 
-    /// Returns the location within the original document
-    pub(crate) fn span(&self) -> Option<std::ops::Range<usize>> {
+    /// The location within the original document
+    ///
+    /// This generally requires a [`Document`][crate::Document].
+    pub fn span(&self) -> Option<std::ops::Range<usize>> {
         self.span.clone()
     }
 


### PR DESCRIPTION
Looking at 444036e, it doesn't make sense why `Table::span` was made private.  All other major types expose their spans, regardless of what quality of meaning or meaning changes.

Fixes #1029