### PR TITLE
Fix nightly build by replacing `doc_auto_cfg` feature with `doc_cfg`

### DIFF
--- a/crates/serde_spanned/src/lib.rs
+++ b/crates/serde_spanned/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! [serde]: https://serde.rs/
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![warn(missing_docs)]
 #![warn(clippy::std_instead_of_core)]

--- a/crates/toml/src/lib.rs
+++ b/crates/toml/src/lib.rs
@@ -139,7 +139,7 @@
 //! [`serde`]: https://serde.rs/
 //! [serde]: https://serde.rs/
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![warn(clippy::std_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]

--- a/crates/toml_datetime/src/lib.rs
+++ b/crates/toml_datetime/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [TOML]: https://github.com/toml-lang/toml
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![warn(missing_docs)]
 #![warn(clippy::std_instead_of_core)]

--- a/crates/toml_edit/src/lib.rs
+++ b/crates/toml_edit/src/lib.rs
@@ -71,7 +71,7 @@
 
 // https://github.com/Marwes/combine/issues/172
 #![recursion_limit = "256"]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![warn(clippy::print_stderr)]
 #![warn(clippy::print_stdout)]

--- a/crates/toml_parser/src/lib.rs
+++ b/crates/toml_parser/src/lib.rs
@@ -14,7 +14,7 @@
 //!    including [decoding keys and values][decoder]
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "unsafe"), forbid(unsafe_code))]
 #![warn(clippy::std_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]

--- a/crates/toml_writer/src/lib.rs
+++ b/crates/toml_writer/src/lib.rs
@@ -49,7 +49,7 @@
 //! ```
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(clippy::std_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]


### PR DESCRIPTION
Fixes this error:

```
error[E0557]: feature has been removed
  --> /github/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/toml_write-0.1.2/src/lib.rs:52:29
   |
52 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`
```