### PR TITLE
perf(toml_edit): reduce llvm-lines in `Option::and_then` calls

### DIFF
--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -319,37 +319,41 @@ impl InlineTable {
     }
     /// Return an optional reference to the value at the given the key.
     pub fn get(&self, key: &str) -> Option<&Value> {
-        self.items.get(key).and_then(|value| value.as_value())
+        let Some(value) = self.items.get(key) else {
+            return None;
+        };
+        value.as_value()
     }
 
     /// Return an optional mutable reference to the value at the given the key.
     pub fn get_mut(&mut self, key: &str) -> Option<&mut Value> {
-        self.items
-            .get_mut(key)
-            .and_then(|value| value.as_value_mut())
+        let Some(value) = self.items.get_mut(key) else {
+            return None;
+        };
+        value.as_value_mut()
     }
 
     /// Return references to the key-value pair stored for key, if it is present, else None.
     pub fn get_key_value<'a>(&'a self, key: &str) -> Option<(&'a Key, &'a Item)> {
-        self.items.get_full(key).and_then(|(_, key, value)| {
-            if !value.is_none() {
-                Some((key, value))
-            } else {
-                None
-            }
-        })
+        let Some((_, key, value)) = self.items.get_full(key) else {
+            return None;
+        };
+        if value.is_none() {
+            return None;
+        }
+        Some((key, value))
     }
 
     /// Return mutable references to the key-value pair stored for key, if it is present, else None.
     pub fn get_key_value_mut<'a>(&'a mut self, key: &str) -> Option<(KeyMut<'a>, &'a mut Item)> {
         use indexmap::map::MutableKeys;
-        self.items.get_full_mut2(key).and_then(|(_, key, value)| {
-            if !value.is_none() {
-                Some((key.as_mut(), value))
-            } else {
-                None
-            }
-        })
+        let Some((_, key, value)) = self.items.get_full_mut2(key) else {
+            return None;
+        };
+        if value.is_none() {
+            return None;
+        }
+        Some((key.as_mut(), value))
     }
 
     /// Returns true if the table contains given key.
@@ -413,16 +417,24 @@ impl InlineTable {
 
     /// Removes an item given the key.
     pub fn remove(&mut self, key: &str) -> Option<Value> {
-        self.items
-            .shift_remove(key)
-            .and_then(|value| value.into_value().ok())
+        let Some(value) = self.items.shift_remove(key) else {
+            return None;
+        };
+        let Ok(value) = value.into_value() else {
+            return None;
+        };
+        Some(value)
     }
 
     /// Removes a key from the map, returning the stored key and value if the key was previously in the map.
     pub fn remove_entry(&mut self, key: &str) -> Option<(Key, Value)> {
-        self.items
-            .shift_remove_entry(key)
-            .and_then(|(key, value)| Some((key, value.into_value().ok()?)))
+        let Some((key, value)) = self.items.shift_remove_entry(key) else {
+            return None;
+        };
+        let Ok(value) = value.into_value() else {
+            return None;
+        };
+        Some((key, value))
     }
 
     /// Retains only the elements specified by the `keep` predicate.

--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -348,39 +348,47 @@ impl Table {
 
     /// Returns an optional reference to an item given the key.
     pub fn get<'a>(&'a self, key: &str) -> Option<&'a Item> {
-        self.items
-            .get(key)
-            .and_then(|value| if !value.is_none() { Some(value) } else { None })
+        let Some(value) = self.items.get(key) else {
+            return None;
+        };
+        if value.is_none() {
+            return None;
+        }
+        Some(value)
     }
 
     /// Returns an optional mutable reference to an item given the key.
     pub fn get_mut<'a>(&'a mut self, key: &str) -> Option<&'a mut Item> {
-        self.items
-            .get_mut(key)
-            .and_then(|value| if !value.is_none() { Some(value) } else { None })
+        let Some(value) = self.items.get_mut(key) else {
+            return None;
+        };
+        if value.is_none() {
+            return None;
+        }
+        Some(value)
     }
 
     /// Return references to the key-value pair stored for key, if it is present, else None.
     pub fn get_key_value<'a>(&'a self, key: &str) -> Option<(&'a Key, &'a Item)> {
-        self.items.get_full(key).and_then(|(_, key, value)| {
-            if !value.is_none() {
-                Some((key, value))
-            } else {
-                None
-            }
-        })
+        let Some((_, key, value)) = self.items.get_full(key) else {
+            return None;
+        };
+        if value.is_none() {
+            return None;
+        }
+        Some((key, value))
     }
 
     /// Return mutable references to the key-value pair stored for key, if it is present, else None.
     pub fn get_key_value_mut<'a>(&'a mut self, key: &str) -> Option<(KeyMut<'a>, &'a mut Item)> {
         use indexmap::map::MutableKeys;
-        self.items.get_full_mut2(key).and_then(|(_, key, value)| {
-            if !value.is_none() {
-                Some((key.as_mut(), value))
-            } else {
-                None
-            }
-        })
+        let Some((_, key, value)) = self.items.get_full_mut2(key) else {
+            return None;
+        };
+        if value.is_none() {
+            return None;
+        }
+        Some((key.as_mut(), value))
     }
 
     /// Returns true if the table contains an item with the given key.


### PR DESCRIPTION
158 less llvm-lines.

- Might reduce compile time of `toml_edit`.

- Removing iterators might be more helpful, like in https://github.com/rust-lang/log/pull/709
  Especially I don't know where `Iterator::try_fold` is coming from.
  Big improvements were made by removing iterators in https://github.com/RustCrypto/formats/pull/1810

Before:
```shell
$ cargo llvm-lines | head -n 20
  Lines                Copies              Function name
  -----                ------              -------------
  58354                2328                (TOTAL)
   1996 (3.4%,  3.4%)    24 (1.0%,  1.0%)  core::iter::traits::iterator::Iterator::try_fold
   1276 (2.2%,  5.6%)     1 (0.0%,  1.1%)  alloc::str::join_generic_copy
   1060 (1.8%,  7.4%)     4 (0.2%,  1.2%)  core::slice::sort::stable::quicksort::stable_partition
    970 (1.7%,  9.1%)    43 (1.8%,  3.1%)  core::option::Option<T>::and_then
    688 (1.2%, 10.3%)    30 (1.3%,  4.4%)  core::option::Option<T>::map
    586 (1.0%, 11.3%)    24 (1.0%,  5.4%)  core::option::Option<T>::unwrap_or_else
    575 (1.0%, 12.3%)     5 (0.2%,  5.6%)  toml_edit::encode::encode_formatted
    565 (1.0%, 13.2%)     1 (0.0%,  5.7%)  core::num::<impl i64>::from_ascii_radix
    540 (0.9%, 14.1%)    15 (0.6%,  6.3%)  <I as core::iter::traits::iterator::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by
    523 (0.9%, 15.0%)    15 (0.6%,  7.0%)  core::iter::traits::iterator::Iterator::nth
    488 (0.8%, 15.9%)     2 (0.1%,  7.0%)  core::slice::sort::shared::smallsort::small_sort_general_with_scratch
    488 (0.8%, 16.7%)     2 (0.1%,  7.1%)  core::slice::sort::stable::drift::sort
    464 (0.8%, 17.5%)     8 (0.3%,  7.5%)  core::option::Option<T>::get_or_insert_with
    457 (0.8%, 18.3%)    12 (0.5%,  8.0%)  <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
    430 (0.7%, 19.0%)     3 (0.1%,  8.1%)  <T as alloc::slice::<impl [T]>::to_vec_in::ConvertVec>::to_vec
    424 (0.7%, 19.8%)    10 (0.4%,  8.5%)  core::iter::traits::iterator::Iterator::find
    414 (0.7%, 20.5%)     4 (0.2%,  8.7%)  <alloc::vec::into_iter::IntoIter<T,A> as core::iter::traits::iterator::Iterator>::try_fold
```

After:
```shell
$ cargo llvm-lines | head -n 20
  Lines                Copies              Function name
  -----                ------              -------------
  58196                2306                (TOTAL)
   1996 (3.4%,  3.4%)    24 (1.0%,  1.0%)  core::iter::traits::iterator::Iterator::try_fold
   1276 (2.2%,  5.6%)     1 (0.0%,  1.1%)  alloc::str::join_generic_copy
   1060 (1.8%,  7.4%)     4 (0.2%,  1.3%)  core::slice::sort::stable::quicksort::stable_partition
    740 (1.3%,  8.7%)    33 (1.4%,  2.7%)  core::option::Option<T>::and_then
    688 (1.2%,  9.9%)    30 (1.3%,  4.0%)  core::option::Option<T>::map
    586 (1.0%, 10.9%)    24 (1.0%,  5.0%)  core::option::Option<T>::unwrap_or_else
    575 (1.0%, 11.9%)     5 (0.2%,  5.2%)  toml_edit::encode::encode_formatted
    565 (1.0%, 12.9%)     1 (0.0%,  5.3%)  core::num::<impl i64>::from_ascii_radix
    540 (0.9%, 13.8%)    15 (0.7%,  5.9%)  <I as core::iter::traits::iterator::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by
    523 (0.9%, 14.7%)    15 (0.7%,  6.6%)  core::iter::traits::iterator::Iterator::nth
    488 (0.8%, 15.5%)     2 (0.1%,  6.7%)  core::slice::sort::shared::smallsort::small_sort_general_with_scratch
    488 (0.8%, 16.4%)     2 (0.1%,  6.8%)  core::slice::sort::stable::drift::sort
    464 (0.8%, 17.2%)     8 (0.3%,  7.1%)  core::option::Option<T>::get_or_insert_with
    457 (0.8%, 17.9%)    12 (0.5%,  7.6%)  <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
    430 (0.7%, 18.7%)     3 (0.1%,  7.8%)  <T as alloc::slice::<impl [T]>::to_vec_in::ConvertVec>::to_vec
    424 (0.7%, 19.4%)    10 (0.4%,  8.2%)  core::iter::traits::iterator::Iterator::find
    414 (0.7%, 20.1%)     4 (0.2%,  8.4%)  <alloc::vec::into_iter::IntoIter<T,A> as core::iter::traits::iterator::Iterator>::try_fold
```
