### PR TITLE
perf(toml): Rewrite `validate_struct_keys`: remove .join()

### DIFF
--- a/crates/toml/src/de/error.rs
+++ b/crates/toml/src/de/error.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use crate::alloc_prelude::*;
 
 /// Errors that can occur when deserializing a type.
@@ -157,9 +159,25 @@ impl core::fmt::Display for Error {
         }
         writeln!(f, "{}", self.message)?;
         if !context && !self.keys.is_empty() {
-            writeln!(f, "in `{}`", self.keys.join("."))?;
+            writeln!(f, "in `{}`", DisplayJoined(".", self.keys.as_slice()))?;
         }
 
+        Ok(())
+    }
+}
+
+pub(crate) struct DisplayJoined<'a, S: Borrow<str>>(pub &'static str, pub &'a [S]);
+
+impl<'a, S: Borrow<str>> alloc::fmt::Display for DisplayJoined<'a, S> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut first = true;
+        for s in self.1 {
+            if !first {
+                f.write_str(self.0)?;
+            }
+            first = false;
+            f.write_str(s.borrow())?;
+        }
         Ok(())
     }
 }

--- a/crates/toml/src/ser/document/buffer.rs
+++ b/crates/toml/src/ser/document/buffer.rs
@@ -57,17 +57,18 @@ impl Buffer {
 
 impl core::fmt::Display for Buffer {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut tables = self
-            .tables
-            .iter()
-            .filter_map(|t| t.as_ref())
-            .filter(|t| required_table(t));
-        if let Some(table) = tables.next() {
-            table.fmt(f)?;
-        }
-        for table in tables {
-            f.newline()?;
-            table.fmt(f)?;
+        let mut newline = false;
+        for table in &self.tables {
+            let Some(table) = table else {
+                continue;
+            };
+            if required_table(table) {
+                if newline {
+                    f.newline()?;
+                }
+                newline = true;
+                table.fmt(f)?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
2156 less llvm-lines, 3% reduction.

- my last attempt failed btw https://github.com/toml-rs/toml/pull/1058

Before:

```shell
toml$ cargo llvm-lines --release | head -n 3
   Compiling toml v0.9.8 (./toml)
  Lines                Copies              Function name
  -----                ------              -------------
  64447                1265                (TOTAL)
```

After:
```shell
toml$ cargo llvm-lines --release | head -n 3
   Compiling toml v0.9.8 (./toml)
  Lines                Copies              Function name
  -----                ------              -------------
  62291                1204                (TOTAL)
```