### PR TITLE
perf(toml_edit): Rewrite array.rs with less llvm-lines

### DIFF
--- a/crates/toml_edit/src/de/table_enum.rs
+++ b/crates/toml_edit/src/de/table_enum.rs
@@ -65,7 +65,7 @@ impl<'de> serde_core::de::VariantAccess<'de> for TableEnumDeserializer {
         match self.value {
             crate::Item::ArrayOfTables(values) => {
                 let values_span = values.span();
-                let tuple_values = values.values.into_iter().collect::<Vec<_>>();
+                let tuple_values = values.values.clone();
 
                 if tuple_values.len() == len {
                     serde_core::de::Deserializer::deserialize_seq(
@@ -81,7 +81,7 @@ impl<'de> serde_core::de::VariantAccess<'de> for TableEnumDeserializer {
             }
             crate::Item::Value(crate::Value::Array(values)) => {
                 let values_span = values.span();
-                let tuple_values = values.values.into_iter().collect::<Vec<_>>();
+                let tuple_values = values.values.clone();
 
                 if tuple_values.len() == len {
                     serde_core::de::Deserializer::deserialize_seq(


### PR DESCRIPTION
85 llvm-lines less

Before:
```
toml_edit$ cargo llvm-lines --release | head -n 5
  Lines                Copies              Function name
  -----                ------              -------------
  53438                1411                (TOTAL)
```

After:
```
toml_edit$ cargo llvm-lines --release | head -n 5
  Lines                Copies              Function name
  -----                ------              -------------
  53353                1408                (TOTAL)
```


Also, this removes `.collect()` in `table_enum.rs`.