### PR TITLE
perf(toml_edit): Rewrite table.rs with less llvm-lines

### DIFF
--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -534,15 +534,14 @@ pub(crate) type KeyValuePairs = IndexMap<Key, Item>;
 
 fn decorate_table(table: &mut Table) {
     use indexmap::map::MutableKeys;
-    for (mut key, value) in table
-        .items
-        .iter_mut2()
-        .filter(|(_, value)| value.is_value())
-        .map(|(key, value)| (key.as_mut(), value.as_value_mut().unwrap()))
-    {
-        key.leaf_decor_mut().clear();
-        key.dotted_decor_mut().clear();
-        value.decor_mut().clear();
+
+    for (key, value) in table.items.iter_mut2() {
+        if let Item::Value(value) = value {
+            let mut key = key.as_mut();
+            key.leaf_decor_mut().clear();
+            key.dotted_decor_mut().clear();
+            value.decor_mut().clear();
+        }
     }
 }
 


### PR DESCRIPTION
192 less llvm lines

Before:
```
toml_edit$ cargo llvm-lines --release | head -n 3
  Lines                Copies              Function name
  -----                ------              -------------
  53438                1411                (TOTAL)
```

After:
```
toml_edit$ cargo llvm-lines --release | head -n 3
  Lines                Copies              Function name
  -----                ------              -------------
  53246                1407                (TOTAL)
```

```
toml_edit$ cargo -V
cargo 1.91.0 (ea2d97820 2025-10-10)
```