### PR TITLE
Allow `InlineTable` insert API to accept `Into<Value>`

### DIFF
--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -377,10 +377,10 @@ impl InlineTable {
     }
 
     /// Inserts a key-value pair into the map.
-    pub fn insert(&mut self, key: impl Into<String>, value: Value) -> Option<Value> {
+    pub fn insert<V: Into<Value>>(&mut self, key: impl Into<String>, value: V) -> Option<Value> {
         use indexmap::map::MutableEntryKey;
         let key = Key::new(key);
-        let value = Item::Value(value);
+        let value = Item::Value(value.into());
         match self.items.entry(key.clone()) {
             indexmap::map::Entry::Occupied(mut entry) => {
                 entry.key_mut().fmt();


### PR DESCRIPTION
This diff updates `InlineTable::insert` to accept any `V: Into<Value>` just like `get_or_insert`, converting internally before storing. This lets callers pass primitive literals (&str, numbers, etc.) without manual Value construction while preserving existing behavior for Value. There are no behavior changes beyond the added flexibility.