### PR TITLE
Table: add clear_position

### DIFF
--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -241,6 +241,11 @@ impl Table {
         self.doc_position = Some(doc_position);
     }
 
+    /// Clears the position of the `Table` within the [`DocumentMut`][crate::DocumentMut].
+    pub fn clear_position(&mut self) {
+        self.doc_position = None;
+    }
+
     /// The position of the `Table` within the [`DocumentMut`][crate::DocumentMut].
     ///
     /// Returns `None` if the `Table` was created manually (i.e. not via parsing)


### PR DESCRIPTION
This has already been discussed in #623. Unlike that case, I don't have any reasonable workaround.
My code combines two config files together, so I need a way to reset position before merging tables.