### PR TITLE
feat: expose span() on TableLike

### DIFF
--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -609,6 +609,10 @@ impl TableLike for InlineTable {
     fn key_mut(&mut self, key: &str) -> Option<KeyMut<'_>> {
         self.key_mut(key)
     }
+
+    fn span(&self) -> Option<std::ops::Range<usize>> {
+        self.span()
+    }
 }
 
 // `{ key1 = value1, ... }`

--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -623,6 +623,10 @@ pub trait TableLike: crate::private::Sealed {
     fn key(&self, key: &str) -> Option<&'_ Key>;
     /// Returns an accessor to a key's formatting
     fn key_mut(&mut self, key: &str) -> Option<KeyMut<'_>>;
+    ////// The location within the original document
+    ///
+    /// This generally requires a [`Document`][crate::Document].
+    fn span(&self) -> Option<std::ops::Range<usize>>;
 }
 
 impl TableLike for Table {
@@ -684,6 +688,10 @@ impl TableLike for Table {
     }
     fn key_mut(&mut self, key: &str) -> Option<KeyMut<'_>> {
         self.key_mut(key)
+    }
+
+    fn span(&self) -> Option<std::ops::Range<usize>> {
+        self.span()
     }
 }
 


### PR DESCRIPTION
TableLike is missing the span() function that both Table and InlineTable have, 
this PR adds it.

I need to know this for my pretty error messages, and would like to be able to use the TableLike abstraction.

I notice that other functions like decor(), retain(), trailing(), trailing_comma() are also missing - so maybe this is by design? 
Or maybe the PR should be larger.

Thanks for all the hard work either way!

PS: Placing the couple of calls was easy. Finding where to add the right tests isn't :).