### PR TITLE
Add support for big integers

### DIFF
--- a/crates/toml_edit/src/de/value.rs
+++ b/crates/toml_edit/src/de/value.rs
@@ -4,6 +4,7 @@ use crate::de::ArrayDeserializer;
 use crate::de::DatetimeDeserializer;
 use crate::de::Error;
 use crate::de::TableDeserializer;
+use crate::value::BigIntValue;
 
 /// Deserialization implementation for TOML [values][crate::Value].
 ///
@@ -67,6 +68,11 @@ impl<'de> serde_core::Deserializer<'de> for ValueDeserializer {
         match self.input {
             crate::Item::None => visitor.visit_none(),
             crate::Item::Value(crate::Value::String(v)) => visitor.visit_string(v.into_value()),
+            crate::Item::Value(crate::Value::BigInteger(v)) => match v.into_value() {
+                BigIntValue::Unsigned64(v) => visitor.visit_u64(v),
+                BigIntValue::Unsigned128(v) => visitor.visit_u128(v),
+                BigIntValue::Signed128(v) => visitor.visit_i128(v),
+            },
             crate::Item::Value(crate::Value::Integer(v)) => visitor.visit_i64(v.into_value()),
             crate::Item::Value(crate::Value::Float(v)) => visitor.visit_f64(v.into_value()),
             crate::Item::Value(crate::Value::Boolean(v)) => visitor.visit_bool(v.into_value()),

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -12,7 +12,7 @@ use crate::table::{
     DEFAULT_KEY_DECOR, DEFAULT_KEY_PATH_DECOR, DEFAULT_ROOT_DECOR, DEFAULT_TABLE_DECOR,
 };
 use crate::value::{
-    DEFAULT_LEADING_VALUE_DECOR, DEFAULT_TRAILING_VALUE_DECOR, DEFAULT_VALUE_DECOR,
+    BigIntValue, DEFAULT_LEADING_VALUE_DECOR, DEFAULT_TRAILING_VALUE_DECOR, DEFAULT_VALUE_DECOR,
 };
 use crate::DocumentMut;
 use crate::{Array, InlineTable, Item, Table, Value};
@@ -193,6 +193,7 @@ pub(crate) fn encode_value(
 ) -> Result {
     match this {
         Value::String(repr) => encode_formatted(repr, buf, input, default_decor),
+        Value::BigInteger(repr) => encode_formatted(repr, buf, input, default_decor),
         Value::Integer(repr) => encode_formatted(repr, buf, input, default_decor),
         Value::Float(repr) => encode_formatted(repr, buf, input, default_decor),
         Value::Boolean(repr) => encode_formatted(repr, buf, input, default_decor),
@@ -332,6 +333,17 @@ impl ValueRepr for String {
             .as_default()
             .to_toml_value();
         Repr::new_unchecked(output)
+    }
+}
+
+impl ValueRepr for BigIntValue {
+    fn to_repr(&self) -> Repr {
+        let repr = match self {
+            Self::Unsigned64(v) => v.to_toml_value(),
+            Self::Unsigned128(v) => v.to_toml_value(),
+            Self::Signed128(v) => v.to_toml_value(),
+        };
+        Repr::new_unchecked(repr)
     }
 }
 

--- a/crates/toml_edit/src/lib.rs
+++ b/crates/toml_edit/src/lib.rs
@@ -138,6 +138,7 @@ pub(crate) mod private {
     impl<T: ?Sized> Sealed for &T where T: Sealed {}
     impl Sealed for crate::Table {}
     impl Sealed for crate::InlineTable {}
+    impl Sealed for crate::value::BigIntValue {}
 }
 
 #[doc = include_str!("../README.md")]

--- a/crates/toml_edit/src/parser/value.rs
+++ b/crates/toml_edit/src/parser/value.rs
@@ -135,6 +135,21 @@ pub(crate) fn on_scalar(
             let value = match i64::from_str_radix(&decoded, radix.value()) {
                 Ok(value) => value,
                 Err(_) => {
+                    if let Ok(v) = u64::from_str_radix(&decoded, radix.value()) {
+                        let mut f = Formatted::new(crate::value::BigIntValue::Unsigned64(v));
+                        f.set_repr_unchecked(Repr::new_unchecked(value_raw));
+                        return Value::BigInteger(f);
+                    }
+                    if let Ok(v) = i128::from_str_radix(&decoded, radix.value()) {
+                        let mut f = Formatted::new(crate::value::BigIntValue::Signed128(v));
+                        f.set_repr_unchecked(Repr::new_unchecked(value_raw));
+                        return Value::BigInteger(f);
+                    }
+                    if let Ok(v) = u128::from_str_radix(&decoded, radix.value()) {
+                        let mut f = Formatted::new(crate::value::BigIntValue::Unsigned128(v));
+                        f.set_repr_unchecked(Repr::new_unchecked(value_raw));
+                        return Value::BigInteger(f);
+                    }
                     // Assuming the decoder fully validated it, leaving only overflow errors
                     errors.report_error(
                         ParseError::new("integer number overflowed").with_unexpected(event.span()),

--- a/crates/toml_edit/src/repr.rs
+++ b/crates/toml_edit/src/repr.rs
@@ -127,8 +127,10 @@ pub trait ValueRepr: crate::private::Sealed {
 #[cfg(not(feature = "display"))]
 mod inner {
     use super::ValueRepr;
+    use crate::value::BigIntValue;
 
     impl ValueRepr for String {}
+    impl ValueRepr for NumberValue {}
     impl ValueRepr for i64 {}
     impl ValueRepr for f64 {}
     impl ValueRepr for bool {}

--- a/crates/toml_edit/src/value.rs
+++ b/crates/toml_edit/src/value.rs
@@ -7,12 +7,33 @@ use crate::key::Key;
 use crate::repr::{Decor, Formatted};
 use crate::{Array, InlineTable, RawString};
 
+/// For allowing `u64`, `i128` and `u128` like the `toml` crate does
+#[derive(Debug, Clone)]
+pub enum BigIntValue {
+    Unsigned64(u64),
+    Signed128(i128),
+    Unsigned128(u128),
+}
+
+#[cfg(feature = "display")]
+impl std::fmt::Display for BigIntValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unsigned64(v) => write!(f, "{v}"),
+            Self::Unsigned128(v) => write!(f, "{v}"),
+            Self::Signed128(v) => write!(f, "{v}"),
+        }
+    }
+}
+
 /// For [`Key`]/Value pairs under a [`Table`][crate::Table] header or inside another
 /// Value
 #[derive(Debug, Clone)]
 pub enum Value {
     /// A string value.
     String(Formatted<String>),
+    /// An up to 128-bit number
+    BigInteger(Formatted<BigIntValue>),
     /// A 64-bit integer value.
     Integer(Formatted<i64>),
     /// A 64-bit float value.
@@ -33,6 +54,7 @@ impl Value {
     pub fn type_name(&self) -> &'static str {
         match self {
             Self::String(..) => "string",
+            Self::BigInteger(..) => "biginteger",
             Self::Integer(..) => "integer",
             Self::Float(..) => "float",
             Self::Boolean(..) => "boolean",
@@ -160,6 +182,7 @@ impl Value {
     pub fn decor_mut(&mut self) -> &mut Decor {
         match self {
             Self::String(f) => f.decor_mut(),
+            Self::BigInteger(f) => f.decor_mut(),
             Self::Integer(f) => f.decor_mut(),
             Self::Float(f) => f.decor_mut(),
             Self::Boolean(f) => f.decor_mut(),
@@ -178,6 +201,7 @@ impl Value {
     pub fn decor(&self) -> &Decor {
         match *self {
             Self::String(ref f) => f.decor(),
+            Self::BigInteger(ref f) => f.decor(),
             Self::Integer(ref f) => f.decor(),
             Self::Float(ref f) => f.decor(),
             Self::Boolean(ref f) => f.decor(),
@@ -213,6 +237,7 @@ impl Value {
     pub fn span(&self) -> Option<std::ops::Range<usize>> {
         match self {
             Self::String(f) => f.span(),
+            Self::BigInteger(f) => f.span(),
             Self::Integer(f) => f.span(),
             Self::Float(f) => f.span(),
             Self::Boolean(f) => f.span(),
@@ -225,6 +250,7 @@ impl Value {
     pub(crate) fn despan(&mut self, input: &str) {
         match self {
             Self::String(f) => f.despan(input),
+            Self::BigInteger(f) => f.despan(input),
             Self::Integer(f) => f.despan(input),
             Self::Float(f) => f.despan(input),
             Self::Boolean(f) => f.despan(input),
@@ -279,9 +305,63 @@ impl From<String> for Value {
     }
 }
 
+impl From<i8> for Value {
+    fn from(i: i8) -> Self {
+        Self::Integer(Formatted::new(i.into()))
+    }
+}
+
+impl From<u8> for Value {
+    fn from(i: u8) -> Self {
+        Self::Integer(Formatted::new(i.into()))
+    }
+}
+
+impl From<i16> for Value {
+    fn from(i: i16) -> Self {
+        Self::Integer(Formatted::new(i.into()))
+    }
+}
+
+impl From<u16> for Value {
+    fn from(i: u16) -> Self {
+        Self::Integer(Formatted::new(i.into()))
+    }
+}
+
+impl From<i32> for Value {
+    fn from(i: i32) -> Self {
+        Self::Integer(Formatted::new(i.into()))
+    }
+}
+
+impl From<u32> for Value {
+    fn from(i: u32) -> Self {
+        Self::Integer(Formatted::new(i.into()))
+    }
+}
+
 impl From<i64> for Value {
     fn from(i: i64) -> Self {
         Self::Integer(Formatted::new(i))
+    }
+}
+
+impl From<u64> for Value {
+    fn from(i: u64) -> Self {
+        Self::BigInteger(Formatted::new(BigIntValue::Unsigned64(i)))
+    }
+}
+
+impl From<u128> for Value {
+    fn from(i: u128) -> Self {
+        Self::BigInteger(Formatted::new(BigIntValue::Unsigned128(i)))
+    }
+}
+
+impl From<i128> for Value {
+    fn from(i: i128) -> Self {
+        Self::BigInteger(Formatted::new(BigIntValue::Signed128(i)))
     }
 }
 

--- a/crates/toml_edit/src/visit.rs
+++ b/crates/toml_edit/src/visit.rs
@@ -75,8 +75,8 @@
 //! [on GitHub](https://github.com/toml-rs/toml/blob/main/crates/toml_edit/examples/visit.rs).
 
 use crate::{
-    Array, ArrayOfTables, Datetime, DocumentMut, Formatted, InlineTable, Item, Table, TableLike,
-    Value,
+    value::BigIntValue, Array, ArrayOfTables, Datetime, DocumentMut, Formatted, InlineTable, Item,
+    Table, TableLike, Value,
 };
 
 /// Document tree traversal to mutate an exclusive borrow of a document tree in-place.
@@ -133,6 +133,10 @@ pub trait Visit<'doc> {
 
     fn visit_integer(&mut self, node: &'doc Formatted<i64>) {
         visit_integer(self, node);
+    }
+
+    fn visit_biginteger(&mut self, node: &'doc Formatted<BigIntValue>) {
+        visit_biginteger(self, node);
     }
 
     fn visit_string(&mut self, node: &'doc Formatted<String>) {
@@ -213,6 +217,7 @@ where
 {
     match node {
         Value::String(s) => v.visit_string(s),
+        Value::BigInteger(n) => v.visit_biginteger(n),
         Value::Integer(i) => v.visit_integer(i),
         Value::Float(f) => v.visit_float(f),
         Value::Boolean(b) => v.visit_boolean(b),
@@ -236,4 +241,5 @@ empty_visit!(visit_boolean, Formatted<bool>);
 empty_visit!(visit_datetime, Formatted<Datetime>);
 empty_visit!(visit_float, Formatted<f64>);
 empty_visit!(visit_integer, Formatted<i64>);
+empty_visit!(visit_biginteger, Formatted<BigIntValue>);
 empty_visit!(visit_string, Formatted<String>);

--- a/crates/toml_edit/src/visit_mut.rs
+++ b/crates/toml_edit/src/visit_mut.rs
@@ -90,8 +90,8 @@
 //! [on GitHub](https://github.com/toml-rs/toml/blob/main/crates/toml_edit/examples/visit.rs).
 
 use crate::{
-    Array, ArrayOfTables, Datetime, DocumentMut, Formatted, InlineTable, Item, KeyMut, Table,
-    TableLike, Value,
+    value::BigIntValue, Array, ArrayOfTables, Datetime, DocumentMut, Formatted, InlineTable, Item,
+    KeyMut, Table, TableLike, Value,
 };
 
 /// Document tree traversal to mutate an exclusive borrow of a document tree in-place.
@@ -150,6 +150,10 @@ pub trait VisitMut {
 
     fn visit_integer_mut(&mut self, node: &mut Formatted<i64>) {
         visit_integer_mut(self, node);
+    }
+
+    fn visit_biginteger_mut(&mut self, node: &mut Formatted<BigIntValue>) {
+        visit_biginteger_mut(self, node);
     }
 
     fn visit_string_mut(&mut self, node: &mut Formatted<String>) {
@@ -230,6 +234,7 @@ where
 {
     match node {
         Value::String(s) => v.visit_string_mut(s),
+        Value::BigInteger(s) => v.visit_biginteger_mut(s),
         Value::Integer(i) => v.visit_integer_mut(i),
         Value::Float(f) => v.visit_float_mut(f),
         Value::Boolean(b) => v.visit_boolean_mut(b),
@@ -253,4 +258,5 @@ empty_visit_mut!(visit_boolean_mut, Formatted<bool>);
 empty_visit_mut!(visit_datetime_mut, Formatted<Datetime>);
 empty_visit_mut!(visit_float_mut, Formatted<f64>);
 empty_visit_mut!(visit_integer_mut, Formatted<i64>);
+empty_visit_mut!(visit_biginteger_mut, Formatted<BigIntValue>);
 empty_visit_mut!(visit_string_mut, Formatted<String>);

--- a/crates/toml_edit/tests/decoder.rs
+++ b/crates/toml_edit/tests/decoder.rs
@@ -45,6 +45,9 @@ fn value_to_decoded(
         toml_edit::Value::Integer(v) => Ok(toml_test_harness::DecodedValue::Scalar(
             toml_test_harness::DecodedScalar::from(*v.value()),
         )),
+        toml_edit::Value::BigInteger(v) => Ok(toml_test_harness::DecodedValue::Scalar(
+            toml_test_harness::DecodedScalar::from(v.value().to_string()),
+        )),
         toml_edit::Value::String(v) => Ok(toml_test_harness::DecodedValue::Scalar(
             toml_test_harness::DecodedScalar::from(v.value()),
         )),

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -689,12 +689,14 @@ fn test_insert_values() {
         root["tbl"]["key1"] = value("value1");
         root["tbl"]["key2"] = value(42);
         root["tbl"]["key3"] = value(8.1415926);
+        root["tbl"]["big"] = u64::MAX.into();
     })
     .produces_display(str![[r#"
 [tbl]
 key1 = "value1"
 key2 = 42
 key3 = 8.1415926
+big = 18446744073709551615
 
         [tbl.son]
 
@@ -1680,4 +1682,11 @@ tool = { typst-test.tests = "tests" }
 
 "#]]
     );
+}
+
+#[test]
+fn big_integers() {
+    let _doc = "number = 18446744073709551615"
+        .parse::<DocumentMut>()
+        .unwrap();
 }


### PR DESCRIPTION
Hello toml_edit team,
For context, I am using toml_edit to write out TOML files with comments, generated from annotated Rust structs.
Since we want to be able to also use big integers for certain config options, and the `toml` crate supports big ints, I figured I'll try to get it working for `toml_edit` too.
The initial PR is a discussion basis, I assume that you might want to feature-gate this or follow a different approach. I am open to discuss and adapt to the needs.

For my use-case those changes make it work for serialising and deserialising, this is therefore a working proof of concept.