### PR TITLE
Revert "fix(toml): Track dotted key for spans"

### DIFF
--- a/crates/toml/src/de/parser/key.rs
+++ b/crates/toml/src/de/parser/key.rs
@@ -86,14 +86,12 @@ fn more_key(input: &Input<'_>) -> bool {
 
 struct State {
     current_key: Option<toml_parser::parser::Event>,
-    start: usize,
 }
 
 impl State {
     fn new(key_event: &toml_parser::parser::Event) -> Self {
         Self {
             current_key: Some(*key_event),
-            start: key_event.span().start(),
         }
     }
 
@@ -110,9 +108,8 @@ impl State {
             return;
         };
 
-        let key_start = self.start;
-        let key_end = key.span().end();
-        let key_span = key_start..key_end;
+        let key_span = key.span();
+        let key_span = key_span.start()..key_span.end();
 
         let raw = source.get(key).unwrap();
         let mut decoded = alloc::borrow::Cow::Borrowed("");

--- a/crates/toml/tests/serde/spanned.rs
+++ b/crates/toml/tests/serde/spanned.rs
@@ -381,8 +381,10 @@ fn test_spanned_nested() {
     }
 
     fn good(s: &str, foo: &Foo) {
-        for v in foo.foo.values() {
-            for n_v in v.values() {
+        for (k, v) in foo.foo.iter() {
+            assert_eq!(&s[k.span().start..k.span().end], k.as_ref());
+            for (n_k, n_v) in v.iter() {
+                assert_eq!(&s[n_k.span().start..n_k.span().end], n_k.as_ref());
                 assert_eq!(
                     &s[(n_v.span().start + 1)..(n_v.span().end - 1)],
                     n_v.as_ref()
@@ -406,7 +408,7 @@ fn test_spanned_nested() {
 Foo {
     foo: {
         Spanned {
-            span: 10..15,
+            span: 14..15,
             value: "a",
         }: {
             Spanned {
@@ -432,7 +434,7 @@ Foo {
             },
         },
         Spanned {
-            span: 74..81,
+            span: 78..81,
             value: "bar",
         }: {
             Spanned {
@@ -688,7 +690,7 @@ Map(
                     [
                         (
                             Spanned {
-                                span: 2..9,
+                                span: 6..9,
                                 value: "bar",
                             },
                             Spanned {
@@ -706,7 +708,7 @@ Map(
                                                     [
                                                         (
                                                             Spanned {
-                                                                span: 11..20,
+                                                                span: 17..20,
                                                                 value: "bob",
                                                             },
                                                             Spanned {
@@ -724,7 +726,7 @@ Map(
                                                                                     [
                                                                                         (
                                                                                             Spanned {
-                                                                                                span: 25..32,
+                                                                                                span: 29..32,
                                                                                                 value: "two",
                                                                                             },
                                                                                             Spanned {
@@ -764,19 +766,19 @@ Map(
     assert_data_eq!(&INPUT[foo.0.span()], str!["foo"]);
     assert_data_eq!(&INPUT[foo.1.span()], str!["foo"]);
     let bar = foo.1.get_ref().get("bar").unwrap();
-    assert_data_eq!(&INPUT[bar.0.span()], str!["foo.bar"]);
+    assert_data_eq!(&INPUT[bar.0.span()], str!["bar"]);
     assert_data_eq!(&INPUT[bar.1.span()], str!["[foo.bar]"]);
     let alice = bar.1.get_ref().get("alice").unwrap();
     assert_data_eq!(&INPUT[alice.0.span()], str!["alice"]);
     assert_data_eq!(&INPUT[alice.1.span()], str!["alice"]);
     let bob = alice.1.get_ref().get("bob").unwrap();
-    assert_data_eq!(&INPUT[bob.0.span()], str!["alice.bob"]);
+    assert_data_eq!(&INPUT[bob.0.span()], str!["bob"]);
     assert_data_eq!(&INPUT[bob.1.span()], str![[r#"{ one.two = "qux" }"#]]);
     let one = bob.1.get_ref().get("one").unwrap();
     assert_data_eq!(&INPUT[one.0.span()], str!["one"]);
     assert_data_eq!(&INPUT[one.1.span()], str!["one"]);
     let two = one.1.get_ref().get("two").unwrap();
-    assert_data_eq!(&INPUT[two.0.span()], str!["one.two"]);
+    assert_data_eq!(&INPUT[two.0.span()], str!["two"]);
     assert_data_eq!(&INPUT[two.1.span()], str![[r#""qux""#]]);
 }
 

--- a/crates/toml/tests/snapshots/invalid/array/extend-defined-aot.stderr
+++ b/crates/toml/tests/snapshots/invalid/array/extend-defined-aot.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 3, column 1
+TOML parse error at line 3, column 5
   |
 3 | arr.val1=1
-  | ^^^^^^^^
+  |     ^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/array/tables-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/array/tables-02.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 9, column 4
+TOML parse error at line 9, column 10
   |
 9 |   [fruit.variety]
-  |    ^^^^^^^^^^^^^
+  |          ^^^^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/ext/table/append-with-dotted-keys-4.stderr
+++ b/crates/toml/tests/snapshots/invalid/ext/table/append-with-dotted-keys-4.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 2, column 1
+TOML parse error at line 2, column 3
   |
 2 | a.b = 2
-  | ^^^
+  |   ^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/ext/table/append-with-dotted-keys-7.stderr
+++ b/crates/toml/tests/snapshots/invalid/ext/table/append-with-dotted-keys-7.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 5, column 2
+TOML parse error at line 5, column 4
   |
 5 | [_.s]
-  |  ^^^
+  |    ^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/ext/table/append-with-dotted-keys-8.stderr
+++ b/crates/toml/tests/snapshots/invalid/ext/table/append-with-dotted-keys-8.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 4, column 2
+TOML parse error at line 4, column 4
   |
 4 | [_.s]
-  |  ^^^
+  |    ^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/ext/table/duplicate-key-1.stderr
+++ b/crates/toml/tests/snapshots/invalid/ext/table/duplicate-key-1.stderr
@@ -1,7 +1,7 @@
-TOML parse error at line 3, column 2
+TOML parse error at line 3, column 4
   |
 3 | [a.b]
-  |  ^^^
+  |    ^
 duplicate key
 
 ---

--- a/crates/toml/tests/snapshots/invalid/inline-table/duplicate-key-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/inline-table/duplicate-key-02.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 1, column 29
+TOML parse error at line 1, column 36
   |
 1 | table1 = { table2.dupe = 1, table2.dupe = 2 }
-  |                             ^^^^^^^^^^^
+  |                                    ^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/inline-table/duplicate-key-04.stderr
+++ b/crates/toml/tests/snapshots/invalid/inline-table/duplicate-key-04.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 1, column 22
+TOML parse error at line 1, column 24
   |
 1 | tbl = { a.b = "a_b", a.b.c = "a_b_c" }
-  |                      ^^^
+  |                        ^
 cannot extend value of type string with a dotted key

--- a/crates/toml/tests/snapshots/invalid/inline-table/overwrite-07.stderr
+++ b/crates/toml/tests/snapshots/invalid/inline-table/overwrite-07.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 1, column 29
+TOML parse error at line 1, column 35
   |
 1 | tab = { inner.table = [{}], inner.table.val = "bad" }
-  |                             ^^^^^^^^^^^
+  |                                   ^^^^^
 cannot extend value of type array with a dotted key

--- a/crates/toml/tests/snapshots/invalid/key/dotted-redefine-table-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/key/dotted-redefine-table-02.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 4, column 1
+TOML parse error at line 4, column 3
   |
 4 | a.b.c = 2
-  | ^^^
+  |   ^
 cannot extend value of type integer with a dotted key

--- a/crates/toml/tests/snapshots/invalid/spec-1.1.0/common-46-0.stderr
+++ b/crates/toml/tests/snapshots/invalid/spec-1.1.0/common-46-0.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 5, column 2
+TOML parse error at line 5, column 8
   |
 5 | [fruit.apple]  # INVALID
-  |  ^^^^^^^^^^^
+  |        ^^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/spec-1.1.0/common-46-1.stderr
+++ b/crates/toml/tests/snapshots/invalid/spec-1.1.0/common-46-1.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 6, column 2
+TOML parse error at line 6, column 14
   |
 6 | [fruit.apple.taste]  # INVALID
-  |  ^^^^^^^^^^^^^^^^^
+  |              ^^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/append-with-dotted-keys-01.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/append-with-dotted-keys-01.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 17, column 3
+TOML parse error at line 17, column 5
    |
 17 |   b.c.t = "Using dotted keys to add to [a.b.c] after explicitly defining it above is not allowed"
-   |   ^^^
+   |     ^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/append-with-dotted-keys-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/append-with-dotted-keys-02.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 8, column 3
+TOML parse error at line 8, column 7
   |
 8 |   b.c.d.k.t = "Using dotted keys to add to [a.b.c.d] after explicitly defining it above is not allowed"
-  |   ^^^^^
+  |       ^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/append-with-dotted-keys-03.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/append-with-dotted-keys-03.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 4, column 1
+TOML parse error at line 4, column 3
   |
 4 | b.y = 2
-  | ^^^
+  |   ^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/append-with-dotted-keys-05.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/append-with-dotted-keys-05.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 2, column 1
+TOML parse error at line 2, column 3
   |
 2 | a.b = 2
-  | ^^^
+  |   ^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/duplicate-key-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/duplicate-key-02.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 4, column 2
+TOML parse error at line 4, column 8
   |
 4 | [fruit.type]
-  |  ^^^^^^^^^^
+  |        ^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/duplicate-key-03.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/duplicate-key-03.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 4, column 3
+TOML parse error at line 4, column 9
   |
 4 | [[fruit.apple]]
-  |   ^^^^^^^^^^^
+  |         ^^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/duplicate-key-04.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/duplicate-key-04.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 4, column 2
+TOML parse error at line 4, column 8
   |
 4 | [fruit.apple] # INVALID
-  |  ^^^^^^^^^^^
+  |        ^^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/duplicate-key-05.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/duplicate-key-05.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 4, column 2
+TOML parse error at line 4, column 14
   |
 4 | [fruit.apple.taste] # INVALID
-  |  ^^^^^^^^^^^^^^^^^
+  |              ^^^^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/duplicate-key-08.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/duplicate-key-08.stderr
@@ -1,7 +1,7 @@
-TOML parse error at line 3, column 2
+TOML parse error at line 3, column 4
   |
 3 | [a.b]
-  |  ^^^
+  |    ^
 duplicate key
 
 ---

--- a/crates/toml/tests/snapshots/invalid/table/redefine-01.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/redefine-01.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 5, column 2
+TOML parse error at line 5, column 4
   |
 5 | [a.b]
-  |  ^^^
+  |    ^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/redefine-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/redefine-02.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 3, column 2
+TOML parse error at line 3, column 5
   |
 3 | [t1.t2]
-  |  ^^^^^
+  |     ^^
 duplicate key

--- a/crates/toml/tests/snapshots/invalid/table/redefine-03.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/redefine-03.stderr
@@ -1,5 +1,5 @@
-TOML parse error at line 3, column 2
+TOML parse error at line 3, column 8
   |
 3 | [t1.t2.t3]
-  |  ^^^^^^^^
+  |        ^^
 duplicate key

--- a/crates/toml_edit/tests/serde/spanned.rs
+++ b/crates/toml_edit/tests/serde/spanned.rs
@@ -381,8 +381,10 @@ fn test_spanned_nested() {
     }
 
     fn good(s: &str, foo: &Foo) {
-        for v in foo.foo.values() {
-            for n_v in v.values() {
+        for (k, v) in foo.foo.iter() {
+            assert_eq!(&s[k.span().start..k.span().end], k.as_ref());
+            for (n_k, n_v) in v.iter() {
+                assert_eq!(&s[n_k.span().start..n_k.span().end], n_k.as_ref());
                 assert_eq!(
                     &s[(n_v.span().start + 1)..(n_v.span().end - 1)],
                     n_v.as_ref()


### PR DESCRIPTION
This reverts commit 87461d819f3383c26b8d9c4e70db208075a7a0d8.

For duplicate key errors, it was somewhat justifiable. When looking at errors in practice, it is not:
```
 [ERROR] invalid character `.` in profile name: `.release-lto`, allowed characters are letters, numbers, underscore, a
nd hyphen
- --> Cargo.toml:8:26
+ --> Cargo.toml:8:18
   |
 8 |                 [profile.'.release-lto']
-  |                          ^^^^^^^^^^^^^^
+  |                  ^^^^^^^^^^^^^^^^^^^^^^
```