### PR TITLE
feat(edit): Support replace() on ArrayOfTables

### DIFF
--- a/crates/toml_edit/src/array_of_tables.rs
+++ b/crates/toml_edit/src/array_of_tables.rs
@@ -99,6 +99,29 @@ impl ArrayOfTables {
         self.values.insert(index, Item::Table(table));
     }
 
+    /// Replaces a table at the given index within the array, returning the old table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= len`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use toml_edit::{ArrayOfTables, Table, value};
+    ///
+    /// let mut arr = ArrayOfTables::new();
+    /// arr.push(Table::from_iter([("name", value("apple"))]));
+    ///
+    /// arr.replace(0, Table::from_iter([("name", value("banana"))]));
+    /// ```
+    pub fn replace(&mut self, index: usize, table: Table) -> Table {
+        match std::mem::replace(&mut self.values[index], Item::Table(table)) {
+            Item::Table(old) => old,
+            x => panic!("non-table item {x:?} in an array of tables"),
+        }
+    }
+
     /// Removes a table with the given index.
     pub fn remove(&mut self, index: usize) -> Table {
         self.values

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -1833,3 +1833,39 @@ baz = 2
 
 "#]]);
 }
+
+#[test]
+fn array_of_tables_replace() {
+    given(
+        r#"[[fruit]]
+name = "apple"
+
+# tropical
+[[fruit]]
+name = "banana"
+"#,
+    )
+    .running(|root| {
+        let array = root["fruit"].as_array_of_tables_mut().unwrap();
+        let mut new_table = Table::new();
+        new_table.insert("name", value("cherry"));
+        let old = array.replace(1, new_table);
+        assert_eq!(old["name"].as_str(), Some("banana"));
+    })
+    .produces_display(str![[r#"
+[[fruit]]
+name = "apple"
+
+[[fruit]]
+name = "cherry"
+
+"#]]);
+}
+
+#[test]
+#[should_panic]
+fn array_of_tables_replace_out_of_bounds() {
+    let mut array = toml_edit::ArrayOfTables::new();
+    let t = Table::new();
+    array.replace(0, t);
+}


### PR DESCRIPTION
As noted in #1122 - ArrayOfTables is missing `replace()` and `sort_by()` and `sort_by_key()` compared to the Array.

I also wrote the naive implementations for the sorts.  But even when the internal `Vec` is successfully sorted, the encode sorts by `position()` regardless - so extra effort is needed to make that do something sensible.

I am sure it cannot be very hard to make this work - but I have a use for `replace` and not for `sort`, so I prefer to leave that for someone who is more motivated.