### PR TITLE
fix(parser): Fix stack overflow in value() on repeated '='

### DIFF
--- a/crates/toml_parser/src/parser/document.rs
+++ b/crates/toml_parser/src/parser/document.rs
@@ -626,27 +626,40 @@ fn opt_dot_keys(
 /// val = string / boolean / array / inline-table / date-time / float / integer
 /// ```
 fn value(tokens: &mut Stream<'_>, receiver: &mut dyn EventReceiver, error: &mut dyn ErrorSink) {
-    let Some(current_token) = tokens.next_token() else {
-        let previous_span = tokens
-            .previous_tokens()
-            .find(|t| {
-                !matches!(
-                    t.kind(),
-                    TokenKind::Whitespace
-                        | TokenKind::Comment
-                        | TokenKind::Newline
-                        | TokenKind::Eof
-                )
-            })
-            .map(|t| t.span())
-            .unwrap_or_default();
+    // Skip extra `=` tokens.
+    let current_token = loop {
+        let Some(current_token) = tokens.next_token() else {
+            let previous_span = tokens
+                .previous_tokens()
+                .find(|t| {
+                    !matches!(
+                        t.kind(),
+                        TokenKind::Whitespace
+                            | TokenKind::Comment
+                            | TokenKind::Newline
+                            | TokenKind::Eof
+                    )
+                })
+                .map(|t| t.span())
+                .unwrap_or_default();
+            error.report_error(
+                ParseError::new("missing value")
+                    .with_context(previous_span)
+                    .with_expected(&[Expected::Description("value")])
+                    .with_unexpected(previous_span.after()),
+            );
+            return;
+        };
+        if current_token.kind() != TokenKind::Equals {
+            break current_token;
+        }
         error.report_error(
-            ParseError::new("missing value")
-                .with_context(previous_span)
-                .with_expected(&[Expected::Description("value")])
-                .with_unexpected(previous_span.after()),
+            ParseError::new("extra `=`")
+                .with_context(current_token.span())
+                .with_expected(&[])
+                .with_unexpected(current_token.span()),
         );
-        return;
+        receiver.error(current_token.span(), error);
     };
 
     match current_token.kind() {
@@ -660,16 +673,8 @@ fn value(tokens: &mut Stream<'_>, receiver: &mut dyn EventReceiver, error: &mut 
             receiver.scalar(fake_key, encoding, error);
             seek(tokens, -1);
         }
-        TokenKind::Equals => {
-            error.report_error(
-                ParseError::new("extra `=`")
-                    .with_context(current_token.span())
-                    .with_expected(&[])
-                    .with_unexpected(current_token.span()),
-            );
-            receiver.error(current_token.span(), error);
-            value(tokens, receiver, error);
-        }
+        // Handled by the while loop above
+        TokenKind::Equals => unreachable!(),
         TokenKind::LeftCurlyBracket => {
             on_inline_table_open(tokens, current_token, receiver, error);
         }

--- a/crates/toml_parser/tests/testsuite/parse_document.rs
+++ b/crates/toml_parser/tests/testsuite/parse_document.rs
@@ -512,3 +512,17 @@ v=1_.2
         file![_].raw(),
     );
 }
+
+#[test]
+fn many_extra_equals() {
+    // Regression test: a long run of `=` does not cause stack overflow.
+    let equals = "=".repeat(5_000);
+    let input = format!("v{equals}1\n");
+
+    let mut actual = crate::EventResults::new(&input);
+    let doc = Source::new(&input);
+    let tokens = doc.lex().into_vec();
+    parse_document(&tokens, &mut actual.events, &mut actual.errors);
+
+    assert!(!actual.errors.is_empty());
+}


### PR DESCRIPTION
Similar to #1129 and #1130

Rewrite the extra '=' handling in value() to iteratively skip redundant '=' tokens in a loop instead of recursing, preventing stack overflow on long runs of '=' characters. Add regression test.

