### PR TITLE
fix(parser): Fix non-ASCII span in decode_unquoted_key

### DIFF
--- a/crates/toml/src/de/error.rs
+++ b/crates/toml/src/de/error.rs
@@ -127,6 +127,11 @@ impl core::fmt::Display for Error {
             let highlight_len = span.end - span.start;
             // Allow highlight to go one past the line
             let highlight_len = highlight_len.min(content.len().saturating_sub(column));
+            // Convert byte length to character count to match the char-based column
+            let highlight_len = input
+                .get(span.start..span.start + highlight_len)
+                .map(|s| s.chars().count())
+                .unwrap_or(highlight_len);
 
             writeln!(f, "TOML parse error at line {line_num}, column {col_num}")?;
             //   |

--- a/crates/toml/tests/snapshots/invalid/encoding/ideographic-space.stderr
+++ b/crates/toml/tests/snapshots/invalid/encoding/ideographic-space.stderr
@@ -3,17 +3,3 @@ TOML parse error at line 2, column 1
 2 | 　foo = "bar"
   | ^
 invalid unquoted key, expected letters, numbers, `-`, `_`
-
----
-TOML parse error at line 2, column 2
-  |
-2 | 　foo = "bar"
-  |  ^
-invalid unquoted key, expected letters, numbers, `-`, `_`
-
----
-TOML parse error at line 2, column 1
-  |
-2 | 　foo = "bar"
-  | ^
-invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml/tests/snapshots/invalid/key/special-character.stderr
+++ b/crates/toml/tests/snapshots/invalid/key/special-character.stderr
@@ -3,10 +3,3 @@ TOML parse error at line 1, column 1
 1 | μ = "greek small letter mu"
   | ^
 invalid unquoted key, expected letters, numbers, `-`, `_`
-
----
-TOML parse error at line 1, column 1
-  |
-1 | μ = "greek small letter mu"
-  | ^
-invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml/tests/snapshots/invalid/table/no-close-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/no-close-02.stderr
@@ -10,10 +10,3 @@ TOML parse error at line 1, column 25
 1 | [closing-bracket.missingö
   |                         ^
 invalid unquoted key, expected letters, numbers, `-`, `_`
-
----
-TOML parse error at line 1, column 25
-  |
-1 | [closing-bracket.missingö
-  |                         ^
-invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml_edit/src/error.rs
+++ b/crates/toml_edit/src/error.rs
@@ -115,6 +115,11 @@ impl std::fmt::Display for TomlError {
             let highlight_len = span.end - span.start;
             // Allow highlight to go one past the line
             let highlight_len = highlight_len.min(content.len().saturating_sub(column));
+            // Convert byte length to character count to match the char-based column
+            let highlight_len = input
+                .get(span.start..span.start + highlight_len)
+                .map(|s| s.chars().count())
+                .unwrap_or(highlight_len);
 
             writeln!(f, "TOML parse error at line {line_num}, column {col_num}")?;
             //   |

--- a/crates/toml_parser/src/decoder/string.rs
+++ b/crates/toml_parser/src/decoder/string.rs
@@ -702,8 +702,8 @@ pub(crate) fn decode_unquoted_key<'i>(
         );
     }
 
-    for (i, b) in s.as_bytes().iter().enumerate() {
-        if !UNQUOTED_CHAR.contains_token(b) {
+    for (i, ch) in s.char_indices() {
+        if !ch.is_ascii() || !UNQUOTED_CHAR.contains_token(&(ch as u8)) {
             error.report_error(
                 ParseError::new("invalid unquoted key")
                     .with_context(Span::new_unchecked(0, s.len()))
@@ -713,7 +713,7 @@ pub(crate) fn decode_unquoted_key<'i>(
                         Expected::Literal("-"),
                         Expected::Literal("_"),
                     ])
-                    .with_unexpected(Span::new_unchecked(i, i)),
+                    .with_unexpected(Span::new_unchecked(i, i + ch.len_utf8())),
             );
         }
     }

--- a/crates/toml_parser/tests/snapshots/testsuite__parse_document__document_invalid.txt
+++ b/crates/toml_parser/tests/snapshots/testsuite__parse_document__document_invalid.txt
@@ -93,7 +93,7 @@ EventResults {
                 ],
             ),
             unexpected: Some(
-                36..36,
+                36..37,
             ),
         },
     ],


### PR DESCRIPTION
Iterate by char (char_indices) instead of by byte, so multi-byte UTF-8 characters produce one error with a correct span rather than one error per byte at potentially mid-codepoint offsets. Also fixes empty spans (i..i) to properly cover the character (i..i+len). Add regression test.