### PR TITLE
fix(parser): Consolidate invalid unquoted key into one error

### DIFF
--- a/crates/toml/tests/snapshots/invalid/encoding/ideographic-space.stderr
+++ b/crates/toml/tests/snapshots/invalid/encoding/ideographic-space.stderr
@@ -1,19 +1,5 @@
 TOML parse error at line 2, column 1
   |
 2 | 　foo = "bar"
-  | ^
-invalid unquoted key, expected letters, numbers, `-`, `_`
-
----
-TOML parse error at line 2, column 2
-  |
-2 | 　foo = "bar"
-  |  ^
-invalid unquoted key, expected letters, numbers, `-`, `_`
-
----
-TOML parse error at line 2, column 1
-  |
-2 | 　foo = "bar"
-  | ^
+  | ^^^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml/tests/snapshots/invalid/key/special-character.stderr
+++ b/crates/toml/tests/snapshots/invalid/key/special-character.stderr
@@ -1,12 +1,5 @@
 TOML parse error at line 1, column 1
   |
 1 | μ = "greek small letter mu"
-  | ^
-invalid unquoted key, expected letters, numbers, `-`, `_`
-
----
-TOML parse error at line 1, column 1
-  |
-1 | μ = "greek small letter mu"
-  | ^
+  | ^^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml/tests/snapshots/invalid/table/no-close-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/no-close-02.stderr
@@ -8,12 +8,5 @@ unclosed table, expected `]`
 TOML parse error at line 1, column 25
   |
 1 | [closing-bracket.missingö
-  |                         ^
-invalid unquoted key, expected letters, numbers, `-`, `_`
-
----
-TOML parse error at line 1, column 25
-  |
-1 | [closing-bracket.missingö
-  |                         ^
+  |                         ^^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml_edit/tests/snapshots/invalid/encoding/ideographic-space.stderr
+++ b/crates/toml_edit/tests/snapshots/invalid/encoding/ideographic-space.stderr
@@ -1,5 +1,5 @@
 TOML parse error at line 2, column 1
   |
 2 | 　foo = "bar"
-  | ^
+  | ^^^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml_edit/tests/snapshots/invalid/key/special-character.stderr
+++ b/crates/toml_edit/tests/snapshots/invalid/key/special-character.stderr
@@ -1,5 +1,5 @@
 TOML parse error at line 1, column 1
   |
 1 | μ = "greek small letter mu"
-  | ^
+  | ^^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml_parser/src/decoder/string.rs
+++ b/crates/toml_parser/src/decoder/string.rs
@@ -702,20 +702,46 @@ pub(crate) fn decode_unquoted_key<'i>(
         );
     }
 
-    for (i, b) in s.as_bytes().iter().enumerate() {
-        if !UNQUOTED_CHAR.contains_token(b) {
-            error.report_error(
-                ParseError::new("invalid unquoted key")
-                    .with_context(Span::new_unchecked(0, s.len()))
-                    .with_expected(&[
-                        Expected::Description("letters"),
-                        Expected::Description("numbers"),
-                        Expected::Literal("-"),
-                        Expected::Literal("_"),
-                    ])
-                    .with_unexpected(Span::new_unchecked(i, i)),
-            );
+    let mut span = None;
+    for (i, _b) in s
+        .as_bytes()
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| !UNQUOTED_CHAR.contains_token(*b))
+    {
+        if let Some((start, end)) = span {
+            if i == end {
+                span = Some((start, i + 1));
+            } else {
+                error.report_error(
+                    ParseError::new("invalid unquoted key")
+                        .with_context(Span::new_unchecked(0, s.len()))
+                        .with_expected(&[
+                            Expected::Description("letters"),
+                            Expected::Description("numbers"),
+                            Expected::Literal("-"),
+                            Expected::Literal("_"),
+                        ])
+                        .with_unexpected(Span::new_unchecked(start, end)),
+                );
+                span = Some((i, i + 1));
+            }
+        } else {
+            span = Some((i, i + 1));
         }
+    }
+    if let Some((start, end)) = span {
+        error.report_error(
+            ParseError::new("invalid unquoted key")
+                .with_context(Span::new_unchecked(0, s.len()))
+                .with_expected(&[
+                    Expected::Description("letters"),
+                    Expected::Description("numbers"),
+                    Expected::Literal("-"),
+                    Expected::Literal("_"),
+                ])
+                .with_unexpected(Span::new_unchecked(start, end)),
+        );
     }
 
     if !output.push_str(s) {

--- a/crates/toml_parser/tests/snapshots/testsuite__parse_document__document_invalid.txt
+++ b/crates/toml_parser/tests/snapshots/testsuite__parse_document__document_invalid.txt
@@ -93,7 +93,7 @@ EventResults {
                 ],
             ),
             unexpected: Some(
-                36..36,
+                36..37,
             ),
         },
     ],


### PR DESCRIPTION
This avoids producing empty spans or spans in the middle of multi-byte characters.

Inspired by #1132