### PR TITLE
fix(parser): use unicode width in error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
+ "unicode-width",
  "walkdir",
  "winnow",
 ]
@@ -1048,6 +1049,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
+ "unicode-width",
  "walkdir",
  "winnow",
 ]
@@ -1097,6 +1099,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/toml/Cargo.toml
+++ b/crates/toml/Cargo.toml
@@ -59,6 +59,7 @@ toml_datetime = { version = "1.1.1", path = "../toml_datetime", default-features
 toml_writer = { version = "1.1.1", path = "../toml_writer", default-features = false, features = ["alloc"], optional = true }
 serde_spanned = { version = "1.1.1", path = "../serde_spanned", default-features = false, features = ["alloc"] }
 foldhash = { version = "0.2.0", default-features = false, optional = true }
+unicode-width = "0.2.2"
 
 [dev-dependencies]
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/toml/src/de/error.rs
+++ b/crates/toml/src/de/error.rs
@@ -1,4 +1,5 @@
 use crate::alloc_prelude::*;
+use unicode_width::UnicodeWidthStr as _;
 
 /// Errors that can occur when deserializing a type.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -124,7 +125,11 @@ impl core::fmt::Display for Error {
             let col_num = column + 1;
             let gutter = line_num.to_string().len();
             let content = input.split('\n').nth(line).expect("valid line number");
-            let highlight_len = span.end - span.start;
+            let highlight_len = input
+                .get(span.start..span.end)
+                .map(|s| s.width())
+                .unwrap_or(span.end - span.start);
+
             // Allow highlight to go one past the line
             let highlight_len = highlight_len.min(content.len().saturating_sub(column));
 
@@ -188,7 +193,7 @@ fn translate_position(input: &[u8], index: usize) -> (usize, usize) {
     let line = input[0..line_start].iter().filter(|b| **b == b'\n').count();
 
     let column = core::str::from_utf8(&input[line_start..=index])
-        .map(|s| s.chars().count() - 1)
+        .map(|s| s.width().saturating_sub(1))
         .unwrap_or_else(|_| index - line_start);
     let column = column + column_offset;
 

--- a/crates/toml/tests/snapshots/invalid/encoding/ideographic-space.stderr
+++ b/crates/toml/tests/snapshots/invalid/encoding/ideographic-space.stderr
@@ -1,5 +1,5 @@
 TOML parse error at line 2, column 1
   |
 2 | 　foo = "bar"
-  | ^^^
+  | ^^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml/tests/snapshots/invalid/key/special-character.stderr
+++ b/crates/toml/tests/snapshots/invalid/key/special-character.stderr
@@ -1,5 +1,5 @@
 TOML parse error at line 1, column 1
   |
 1 | μ = "greek small letter mu"
-  | ^^
+  | ^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml/tests/snapshots/invalid/table/no-close-02.stderr
+++ b/crates/toml/tests/snapshots/invalid/table/no-close-02.stderr
@@ -8,5 +8,5 @@ unclosed table, expected `]`
 TOML parse error at line 1, column 25
   |
 1 | [closing-bracket.missingö
-  |                         ^^
+  |                         ^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml_edit/Cargo.toml
+++ b/crates/toml_edit/Cargo.toml
@@ -48,6 +48,7 @@ toml_writer = { version = "1.1.1", path = "../toml_writer", optional = true }
 toml_parser = { version = "1.1.2", path = "../toml_parser", optional = true }
 anstream = { version = "1.0.0", optional = true }
 anstyle = { version = "1.0.14", optional = true }
+unicode-width = "0.2.2"
 
 [dev-dependencies]
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/toml_edit/src/error.rs
+++ b/crates/toml_edit/src/error.rs
@@ -1,3 +1,5 @@
+use unicode_width::UnicodeWidthStr as _;
+
 /// A TOML parse error
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct TomlError {
@@ -112,7 +114,11 @@ impl std::fmt::Display for TomlError {
             let col_num = column + 1;
             let gutter = line_num.to_string().len();
             let content = input.split('\n').nth(line).expect("valid line number");
-            let highlight_len = span.end - span.start;
+            let highlight_len = input
+                .get(span.start..span.end)
+                .map(|s| s.width())
+                .unwrap_or(span.end - span.start);
+
             // Allow highlight to go one past the line
             let highlight_len = highlight_len.min(content.len().saturating_sub(column));
 
@@ -176,7 +182,7 @@ fn translate_position(input: &[u8], index: usize) -> (usize, usize) {
     let line = input[0..line_start].iter().filter(|b| **b == b'\n').count();
 
     let column = std::str::from_utf8(&input[line_start..=index])
-        .map(|s| s.chars().count() - 1)
+        .map(|s| s.width().saturating_sub(1))
         .unwrap_or_else(|_| index - line_start);
     let column = column + column_offset;
 

--- a/crates/toml_edit/tests/snapshots/invalid/encoding/ideographic-space.stderr
+++ b/crates/toml_edit/tests/snapshots/invalid/encoding/ideographic-space.stderr
@@ -1,5 +1,5 @@
 TOML parse error at line 2, column 1
   |
 2 | 　foo = "bar"
-  | ^^^
+  | ^^
 invalid unquoted key, expected letters, numbers, `-`, `_`

--- a/crates/toml_edit/tests/snapshots/invalid/key/special-character.stderr
+++ b/crates/toml_edit/tests/snapshots/invalid/key/special-character.stderr
@@ -1,5 +1,5 @@
 TOML parse error at line 1, column 1
   |
 1 | μ = "greek small letter mu"
-  | ^^
+  | ^
 invalid unquoted key, expected letters, numbers, `-`, `_`


### PR DESCRIPTION
Recognising that you may not want the dependency - I thought I would at least give you a pull request you can turn down.

Using `unicode-width`, we can highlight the right number of columns, instead of just counting the bytes.

Fixes #1120