### PR TITLE
docs(toml_edit): document trailing newline limitation

### DIFF
--- a/crates/toml_edit/README.md
+++ b/crates/toml_edit/README.md
@@ -41,6 +41,7 @@ c = { d = "hello" }
 Things it does not preserve:
 
 * Order of dotted keys, see [issue](https://github.com/toml-rs/toml/issues/163).
+* Lack of trailing newline, see [issue](https://github.com/toml-rs/toml/issues/1158).
 
 ## License
 

--- a/crates/toml_edit/src/lib.rs
+++ b/crates/toml_edit/src/lib.rs
@@ -66,6 +66,7 @@
 //! Things it does not preserve:
 //!
 //! * Order of dotted keys, see [issue](https://github.com/toml-rs/toml/issues/163).
+//! * Lack of trailing newline, see [issue](https://github.com/toml-rs/toml/issues/1158).
 //!
 //! [`toml`]: https://docs.rs/toml/latest/toml/
 


### PR DESCRIPTION
Closes #1158.

## Summary

Document that `toml_edit` normalizes output to end with a trailing newline and does not preserve whether the input omitted it.

Add the note to both the crate README and the crate-level docs alongside the existing limitations section.

## Repro

```rust
let input = "answer = 42";
let doc = input.parse::<toml_edit::DocumentMut>()?;
assert_eq!(doc.to_string(), "answer = 42\n");
```

## Validation

- `cargo fmt --all --check`
- `cargo test -p toml_edit`
- `cargo clippy -p toml_edit --lib -- -D warnings`
- `/private/tmp/prek-venv/bin/prek run --all-files`
