### PR TITLE
fix(toml): preserve datetimes when deserializing Value

### DIFF
--- a/crates/toml/src/table.rs
+++ b/crates/toml/src/table.rs
@@ -157,9 +157,21 @@ impl<'de> de::Deserializer<'de> for Table {
         Value::Table(self).deserialize_newtype_struct(name, visitor)
     }
 
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, crate::de::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Value::Table(self).deserialize_struct(name, fields, visitor)
+    }
+
     serde_core::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit seq
-        bytes byte_buf map unit_struct tuple_struct struct
+        bytes byte_buf map unit_struct tuple_struct
         tuple ignored_any identifier
     }
 }

--- a/crates/toml/src/value.rs
+++ b/crates/toml/src/value.rs
@@ -608,9 +608,26 @@ impl<'de> de::Deserializer<'de> for Value {
         visitor.visit_newtype_struct(self)
     }
 
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, crate::de::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match (toml_datetime::de::is_datetime(name), self) {
+            (true, Self::Datetime(v)) => {
+                visitor.visit_map(toml_datetime::de::DatetimeDeserializer::new(v))
+            }
+            (_, value) => value.deserialize_any(visitor),
+        }
+    }
+
     serde_core::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit seq
-        bytes byte_buf map unit_struct tuple_struct struct
+        bytes byte_buf map unit_struct tuple_struct
         tuple ignored_any identifier
     }
 }

--- a/crates/toml/tests/serde/general.rs
+++ b/crates/toml/tests/serde/general.rs
@@ -1492,6 +1492,25 @@ fn table_type_enum_regression_issue_388() {
 }
 
 #[test]
+fn deserialize_datetime_from_value_issue_440() {
+    let input = "1979-05-27T07:32:00Z";
+    let value = crate::value_from_str::<crate::SerdeValue>(input).unwrap();
+
+    let json = value.clone().try_into::<serde_json::Value>().unwrap();
+    assert_eq!(json, serde_json::Value::String(input.to_owned()));
+
+    let error = value.try_into::<crate::Datetime>().unwrap_err();
+    assert_data_eq!(
+        error.to_string(),
+        str![[r#"
+invalid type: string "1979-05-27T07:32:00Z", expected a TOML datetime
+
+"#]]
+        .raw()
+    );
+}
+
+#[test]
 fn serialize_datetime_issue_333() {
     #[derive(Serialize)]
     struct Struct {

--- a/crates/toml/tests/serde/general.rs
+++ b/crates/toml/tests/serde/general.rs
@@ -1499,15 +1499,8 @@ fn deserialize_datetime_from_value_issue_440() {
     let json = value.clone().try_into::<serde_json::Value>().unwrap();
     assert_eq!(json, serde_json::Value::String(input.to_owned()));
 
-    let error = value.try_into::<crate::Datetime>().unwrap_err();
-    assert_data_eq!(
-        error.to_string(),
-        str![[r#"
-invalid type: string "1979-05-27T07:32:00Z", expected a TOML datetime
-
-"#]]
-        .raw()
-    );
+    let datetime = value.try_into::<crate::Datetime>().unwrap();
+    assert_eq!(datetime.to_string(), input);
 }
 
 #[test]

--- a/crates/toml_edit/tests/serde/general.rs
+++ b/crates/toml_edit/tests/serde/general.rs
@@ -1369,6 +1369,25 @@ fn table_type_enum_regression_issue_388() {
 }
 
 #[test]
+fn deserialize_datetime_from_value_issue_440() {
+    let input = "1979-05-27T07:32:00Z";
+    let value = crate::value_from_str::<crate::SerdeValue>(input).unwrap();
+
+    let json = value.clone().try_into::<serde_json::Value>().unwrap();
+    assert_eq!(json, serde_json::Value::String(input.to_owned()));
+
+    let error = value.try_into::<crate::Datetime>().unwrap_err();
+    assert_data_eq!(
+        error.to_string(),
+        str![[r#"
+invalid type: string "1979-05-27T07:32:00Z", expected a TOML datetime
+
+"#]]
+        .raw()
+    );
+}
+
+#[test]
 fn serialize_datetime_issue_333() {
     #[derive(Serialize)]
     struct Struct {

--- a/crates/toml_edit/tests/serde/general.rs
+++ b/crates/toml_edit/tests/serde/general.rs
@@ -1376,15 +1376,8 @@ fn deserialize_datetime_from_value_issue_440() {
     let json = value.clone().try_into::<serde_json::Value>().unwrap();
     assert_eq!(json, serde_json::Value::String(input.to_owned()));
 
-    let error = value.try_into::<crate::Datetime>().unwrap_err();
-    assert_data_eq!(
-        error.to_string(),
-        str![[r#"
-invalid type: string "1979-05-27T07:32:00Z", expected a TOML datetime
-
-"#]]
-        .raw()
-    );
+    let datetime = value.try_into::<crate::Datetime>().unwrap();
+    assert_eq!(datetime.to_string(), input);
 }
 
 #[test]


### PR DESCRIPTION
Closes #440.

## Summary

Fix explicit deserialization of TOML datetimes from `toml::Value` without
changing generic cross-format conversions.

`toml::value::Datetime` asks Serde for TOML's private datetime struct. The
legacy `toml::Value` deserializer forwarded `deserialize_struct` to
`deserialize_any`, where `Value::Datetime` is represented as a string. Typed
conversions therefore failed with:

```text
invalid type: string "1979-05-27T07:32:00Z", expected a TOML datetime
```

## What changed

- Handle TOML's private datetime struct in `Value::deserialize_struct`.
- Forward `Table::deserialize_struct` to the `Value` implementation.
- Keep `deserialize_any` unchanged so generic JSON conversion still produces
  a string.
- Add synchronized regression coverage to the `toml` and `toml_edit` Serde
  test suites.
- No new dependencies.

## Behavioral impact

`Value::try_into::<toml::value::Datetime>()` now succeeds for
`Value::Datetime`, while converting the same value into `serde_json::Value`
continues to produce a JSON string.

Other `toml::Value` variants and ordinary struct deserialization are
unchanged.

## Scope

The separate `Value::try_from` serialization behavior mentioned later in
#440 uses a different serializer path and is intentionally unchanged.

## Validation

- [x] `cargo +1.97.0 test -p toml --test serde general::deserialize_datetime_from_value_issue_440 -- --exact --nocapture`
- [x] `cargo +1.97.0 test -p toml_edit --features serde --test serde general::deserialize_datetime_from_value_issue_440 -- --exact --nocapture`
- [x] `cargo +1.97.0 test -p toml --test serde` (173 passed)
- [x] `cargo +1.97.0 test -p toml_edit --features serde --test serde` (163 passed)
- [x] `cargo +1.97.0 check -p toml --no-default-features --features serde --locked`
- [x] `cargo +1.97.0 clippy -p toml -p toml_edit --all-features --all-targets -- -D warnings`
- [x] `cargo +1.97.0 fmt --all --check`
