### PR TITLE
fix(edit): preserve tables when displaying an owned Document

### DIFF
--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -6,6 +6,7 @@ use toml_writer::ToTomlValue as _;
 use toml_writer::TomlWrite as _;
 
 use crate::DocumentMut;
+use crate::RawString;
 use crate::inline_table::DEFAULT_INLINE_KEY_DECOR;
 use crate::key::Key;
 use crate::repr::{Decor, Formatted, Repr, ValueRepr};
@@ -202,30 +203,54 @@ pub(crate) fn encode_value(
     }
 }
 
+fn encode_document(
+    buf: &mut dyn Write,
+    input: Option<&str>,
+    decor: &Decor,
+    root: &Table,
+    trailing: &RawString,
+) -> Result {
+    decor.prefix_encode(buf, input, DEFAULT_ROOT_DECOR.0)?;
+
+    let mut path = Vec::new();
+    let mut last_position = 0;
+    let mut tables = Vec::new();
+    visit_nested_tables(root, &mut path, false, &mut |t, p, is_array| {
+        if let Some(pos) = t.position() {
+            last_position = pos;
+        }
+        tables.push((last_position, t, p.clone(), is_array));
+        Ok(())
+    })
+    .unwrap();
+
+    tables.sort_by_key(|(id, _, path, _)| (!path.is_empty(), *id));
+    let mut first_table = true;
+    for (_, table, path, is_array) in tables {
+        visit_table(buf, input, table, &path, is_array, &mut first_table)?;
+    }
+    decor.suffix_encode(buf, input, DEFAULT_ROOT_DECOR.1)?;
+    trailing.encode_with_default(buf, input, "")
+}
+
 impl Display for DocumentMut {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let decor = self.decor();
-        decor.prefix_encode(f, None, DEFAULT_ROOT_DECOR.0)?;
+        encode_document(f, None, self.decor(), self.as_table(), self.trailing())
+    }
+}
 
-        let mut path = Vec::new();
-        let mut last_position = 0;
-        let mut tables = Vec::new();
-        visit_nested_tables(self.as_table(), &mut path, false, &mut |t, p, is_array| {
-            if let Some(pos) = t.position() {
-                last_position = pos;
-            }
-            tables.push((last_position, t, p.clone(), is_array));
-            Ok(())
-        })
-        .unwrap();
-
-        tables.sort_by_key(|(id, _, path, _)| (!path.is_empty(), *id));
-        let mut first_table = true;
-        for (_, table, path, is_array) in tables {
-            visit_table(f, None, table, &path, is_array, &mut first_table)?;
-        }
-        decor.suffix_encode(f, None, DEFAULT_ROOT_DECOR.1)?;
-        self.trailing().encode_with_default(f, None, "")
+impl<S: AsRef<str>> Display for crate::Document<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        // `Document<S>` keeps the parsed tree spanned against the original
+        // source, so resolve the decor/reprs against it (unlike `DocumentMut`,
+        // which is despanned and passes `None`).
+        encode_document(
+            f,
+            Some(self.raw()),
+            self.decor(),
+            self.as_table(),
+            self.trailing(),
+        )
     }
 }
 

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -1899,3 +1899,27 @@ fn array_of_tables_replace_out_of_bounds() {
     let t = Table::new();
     array.replace(0, t);
 }
+
+#[test]
+fn document_string_display_matches_source() {
+    // Regression for https://github.com/toml-rs/toml/issues/1008: `Document<S>`
+    // had no `Display` of its own, so `to_string()` resolved through its `Deref`
+    // to `Table`, which dropped `[table]` headers and produced an empty string.
+    // It must losslessly round-trip its source, matching `DocumentMut`.
+    let inputs = [
+        "\n[project]\nx = \"y\"\n",
+        "a = 1\n",
+        "# leading\n[a.b]\nc = 2\n\n[[arr]]\nx = 1\n",
+        "",
+    ];
+    for input in inputs {
+        let doc = input.parse::<toml_edit::Document<String>>().unwrap();
+        assert_eq!(doc.to_string(), input, "Document<String> should round-trip");
+        let doc_mut = input.parse::<DocumentMut>().unwrap();
+        assert_eq!(
+            doc.to_string(),
+            doc_mut.to_string(),
+            "Document<String> should match DocumentMut"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`toml_edit::Document<String>::to_string()` returns an empty string when the document contains a `[table]` header (#1008):

```rust
let doc = "\n[project]\nx = \"y\"\n".parse::<toml_edit::Document<String>>().unwrap();
assert_eq!(doc.to_string(), ""); // before this PR
```

`DocumentMut` round-trips the same input correctly.

## Root cause

`Document<S>` has no `Display` impl of its own; it only `Deref`s to `Table`, so `to_string()` resolves to `<Table as Display>`, which renders the root table's *direct* items but not the `[table]` headers of nested tables. The document-level logic that emits those headers (`visit_nested_tables` + sorting by position) lives solely in `impl Display for DocumentMut`. So a document whose content lives under a header renders as nothing.

## Fix

Extract the document-encoding body into a shared `encode_document(buf, input, decor, root, trailing)` helper and give `Document<S>` its own `Display`. Because `Document<S>` keeps the parsed tree spanned against its retained source, it passes `Some(self.raw())` so the decor/reprs resolve against that source; `DocumentMut` is despanned and keeps passing `None`. `DocumentMut`'s output is byte-for-byte unchanged.

`Document<String>::to_string()` now losslessly round-trips its input and matches `DocumentMut`.

## Tests

Added a regression test in `tests/testsuite/edit.rs` covering the `[table]` case (plus a root-only case, a nested/array-of-tables case, and empty input), asserting `Document<String>::to_string()` equals the source and matches `DocumentMut`. Full `cargo test -p toml_edit -p toml` passes, `cargo fmt --check` is clean, and there are no new clippy warnings.

I saw your note that this needs more thought on how it should be fixed, so I'm happy to adjust the approach if you'd prefer different semantics (e.g. a different `Display` for the immutable document, or not exposing `to_string()` on it at all).

Fixes #1008.

---

Disclosure: this fix was developed with AI assistance; I reviewed it and stand behind it.
