### PR TITLE
fix: Docs for `to_string_pretty` functions

### DIFF
--- a/crates/toml/src/ser/mod.rs
+++ b/crates/toml/src/ser/mod.rs
@@ -74,8 +74,8 @@ where
 
 /// Serialize the given data structure as a "pretty" String of TOML.
 ///
-/// This is identical to `to_string` except the output string has a more
-/// "pretty" output. See `Serializer::pretty` for more details.
+/// This is identical to [`to_string`] except the output string has a more
+/// "pretty" output. See [`Serializer::pretty`] for more details.
 ///
 /// To serialize TOML values, instead of documents, see [`ValueSerializer`].
 ///

--- a/crates/toml_edit/src/ser/mod.rs
+++ b/crates/toml_edit/src/ser/mod.rs
@@ -77,8 +77,8 @@ where
 
 /// Serialize the given data structure as a "pretty" String of TOML.
 ///
-/// This is identical to `to_string` except the output string has a more
-/// "pretty" output. See `ValueSerializer::pretty` for more details.
+/// This is identical to [`to_string`] except the output string has a more
+/// "pretty" output.
 #[cfg(feature = "display")]
 pub fn to_string_pretty<T>(value: &T) -> Result<String, Error>
 where


### PR DESCRIPTION
`ValueSerializer::pretty` does not exist