### PR TITLE
perf: Reduce allocations in toml_edit parsing and dumping

### DIFF
--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -41,5 +41,9 @@ harness = false
 name = "2-array"
 harness = false
 
+[[bench]]
+name = "3-keys"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -10,6 +10,7 @@ release = false
 
 [features]
 default = []
+alloc-profiler = []
 simd = ["toml_parser/simd"]
 unsafe = ["toml_parser/unsafe"]
 preserve_order = ["serde_json/preserve_order", "toml_old/preserve_order", "toml/preserve_order"]

--- a/crates/benchmarks/benches/0-cargo.rs
+++ b/crates/benchmarks/benches/0-cargo.rs
@@ -1,5 +1,9 @@
 #![allow(elided_lifetimes_in_paths)]
 
+#[cfg(feature = "alloc-profiler")]
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+
 mod toml_parser {
     use toml_benchmarks::{Data, MANIFESTS};
 

--- a/crates/benchmarks/benches/0-cargo.rs
+++ b/crates/benchmarks/benches/0-cargo.rs
@@ -93,6 +93,15 @@ mod toml_edit {
     }
 
     #[divan::bench(args=MANIFESTS)]
+    fn dump(bencher: divan::Bencher, sample: &Data<'static>) {
+        let document = sample
+            .content()
+            .parse::<::toml_edit::DocumentMut>()
+            .unwrap();
+        bencher.bench(|| std::hint::black_box(&document).to_string());
+    }
+
+    #[divan::bench(args=MANIFESTS)]
     fn manifest(sample: &Data<'static>) -> manifest::Manifest {
         ::toml_edit::de::from_str(sample.content()).unwrap()
     }
@@ -122,6 +131,12 @@ mod toml {
     }
 
     #[divan::bench(args=MANIFESTS)]
+    fn dump(bencher: divan::Bencher, sample: &Data<'static>) {
+        let document = sample.content().parse::<::toml::Table>().unwrap();
+        bencher.bench(|| ::toml::to_string(std::hint::black_box(&document)).unwrap());
+    }
+
+    #[divan::bench(args=MANIFESTS)]
     fn manifest(sample: &Data<'static>) -> manifest::Manifest {
         ::toml::de::from_str(sample.content()).unwrap()
     }
@@ -133,6 +148,12 @@ mod toml_v05 {
     #[divan::bench(args=MANIFESTS)]
     fn document(sample: &Data<'static>) -> ::toml_old::Value {
         sample.content().parse().unwrap()
+    }
+
+    #[divan::bench(args=MANIFESTS)]
+    fn dump(bencher: divan::Bencher, sample: &Data<'static>) {
+        let document = sample.content().parse::<::toml_old::Value>().unwrap();
+        bencher.bench(|| ::toml_old::to_string(std::hint::black_box(&document)).unwrap());
     }
 
     #[divan::bench(args=MANIFESTS)]
@@ -156,6 +177,12 @@ mod serde_json {
             .bench_values(|sample| {
                 serde_json::from_str::<::toml::Value>(sample.content()).unwrap()
             });
+    }
+
+    #[divan::bench(args=MANIFESTS)]
+    fn dump(bencher: divan::Bencher, sample: &Data<'static>) {
+        let document = toml_edit::de::from_str::<::serde_json::Value>(sample.content()).unwrap();
+        bencher.bench(|| ::serde_json::to_string(std::hint::black_box(&document)).unwrap());
     }
 
     #[divan::bench(args=MANIFESTS)]

--- a/crates/benchmarks/benches/1-map.rs
+++ b/crates/benchmarks/benches/1-map.rs
@@ -1,5 +1,9 @@
 #![allow(elided_lifetimes_in_paths)]
 
+#[cfg(feature = "alloc-profiler")]
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+
 const NUM_ENTRIES: &[usize] = &[10, 100];
 
 mod toml_parser {

--- a/crates/benchmarks/benches/1-map.rs
+++ b/crates/benchmarks/benches/1-map.rs
@@ -116,6 +116,14 @@ mod toml_edit {
             .input_counter(divan::counter::BytesCount::of_str)
             .bench_values(|sample| sample.parse::<toml_edit::DocumentMut>().unwrap());
     }
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn dump(bencher: divan::Bencher, num_entries: usize) {
+        let document = generate(num_entries)
+            .parse::<toml_edit::DocumentMut>()
+            .unwrap();
+        bencher.bench(|| std::hint::black_box(&document).to_string());
+    }
 }
 
 mod toml {
@@ -149,6 +157,12 @@ mod toml {
             .input_counter(divan::counter::BytesCount::of_str)
             .bench_values(|sample| sample.parse::<toml::Table>().unwrap());
     }
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn dump(bencher: divan::Bencher, num_entries: usize) {
+        let document = generate(num_entries).parse::<toml::Table>().unwrap();
+        bencher.bench(|| toml::to_string(std::hint::black_box(&document)).unwrap());
+    }
 }
 
 mod toml_v05 {
@@ -161,6 +175,12 @@ mod toml_v05 {
             .with_inputs(|| generate(num_entries))
             .input_counter(divan::counter::BytesCount::of_str)
             .bench_values(|sample| sample.parse::<toml_old::Value>().unwrap());
+    }
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn dump(bencher: divan::Bencher, num_entries: usize) {
+        let document = generate(num_entries).parse::<toml_old::Value>().unwrap();
+        bencher.bench(|| toml_old::to_string(std::hint::black_box(&document)).unwrap());
     }
 }
 

--- a/crates/benchmarks/benches/2-array.rs
+++ b/crates/benchmarks/benches/2-array.rs
@@ -1,5 +1,9 @@
 #![allow(elided_lifetimes_in_paths)]
 
+#[cfg(feature = "alloc-profiler")]
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+
 const NUM_ENTRIES: &[usize] = &[10, 100];
 
 mod toml_parser {

--- a/crates/benchmarks/benches/2-array.rs
+++ b/crates/benchmarks/benches/2-array.rs
@@ -116,6 +116,14 @@ mod toml_edit {
             .input_counter(divan::counter::BytesCount::of_str)
             .bench_values(|sample| sample.parse::<toml_edit::DocumentMut>().unwrap());
     }
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn dump(bencher: divan::Bencher, num_entries: usize) {
+        let document = generate(num_entries)
+            .parse::<toml_edit::DocumentMut>()
+            .unwrap();
+        bencher.bench(|| std::hint::black_box(&document).to_string());
+    }
 }
 
 mod toml {
@@ -149,6 +157,12 @@ mod toml {
             .input_counter(divan::counter::BytesCount::of_str)
             .bench_values(|sample| sample.parse::<toml::Table>().unwrap());
     }
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn dump(bencher: divan::Bencher, num_entries: usize) {
+        let document = generate(num_entries).parse::<toml::Table>().unwrap();
+        bencher.bench(|| toml::to_string(std::hint::black_box(&document)).unwrap());
+    }
 }
 
 mod toml_v05 {
@@ -161,6 +175,12 @@ mod toml_v05 {
             .with_inputs(|| generate(num_entries))
             .input_counter(divan::counter::BytesCount::of_str)
             .bench_values(|sample| sample.parse::<toml_old::Value>().unwrap());
+    }
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn dump(bencher: divan::Bencher, num_entries: usize) {
+        let document = generate(num_entries).parse::<toml_old::Value>().unwrap();
+        bencher.bench(|| toml_old::to_string(std::hint::black_box(&document)).unwrap());
     }
 }
 

--- a/crates/benchmarks/benches/3-keys.rs
+++ b/crates/benchmarks/benches/3-keys.rs
@@ -1,0 +1,35 @@
+#![allow(elided_lifetimes_in_paths)]
+
+#[cfg(feature = "alloc-profiler")]
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+
+const NUM_ENTRIES: &[usize] = &[10, 100];
+
+mod toml_edit {
+    use crate::NUM_ENTRIES;
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn dump(bencher: divan::Bencher, entries: usize) {
+        let mut document = ::toml_edit::DocumentMut::new();
+        for i in 0..entries {
+            let key = if i % 2 == 0 {
+                format!("key_{i}")
+            } else {
+                format!("key {i}")
+            };
+            let value = match i % 4 {
+                0 => ::toml_edit::Value::from("a generated string"),
+                1 => ::toml_edit::Value::from(i64::try_from(i).unwrap()),
+                2 => ::toml_edit::Value::from(true),
+                _ => ::toml_edit::Value::from(1.25),
+            };
+            document.insert(&key, ::toml_edit::Item::Value(value));
+        }
+        bencher.bench(|| std::hint::black_box(&document).to_string());
+    }
+}
+
+fn main() {
+    divan::main();
+}

--- a/crates/toml/src/de/parser/document.rs
+++ b/crates/toml/src/de/parser/document.rs
@@ -262,7 +262,7 @@ impl<'i> State<'i> {
         let _scope = TraceScope::new("document::finish_table");
         let prev_table = core::mem::take(&mut self.current_table);
         if let Some(header) = self.current_header.take() {
-            let Some(key) = &header.key else {
+            let Some(key) = header.key else {
                 return;
             };
             let header_span = header.span.start()..header.span.end();
@@ -280,7 +280,8 @@ impl<'i> State<'i> {
                 anstyle::AnsiColor::Blue.on_default(),
             );
             if header.is_array {
-                let entry = parent_table.entry(key.clone()).or_insert_with(|| {
+                let key_span = get_key_span(&key);
+                let entry = parent_table.entry(key).or_insert_with(|| {
                     let mut array = DeArray::new();
                     array.set_array_of_tables(true);
                     Spanned::new(header_span, DeValue::Array(array))
@@ -295,7 +296,6 @@ impl<'i> State<'i> {
                         "is_array_of_tables=false",
                         anstyle::AnsiColor::Red.on_default(),
                     );
-                    let key_span = get_key_span(key);
                     let old_span = entry.span();
                     let old_span = toml_parser::Span::new_unchecked(old_span.start, old_span.end);
                     errors.report_error(
@@ -307,7 +307,7 @@ impl<'i> State<'i> {
                 };
                 array.push(prev_table);
             } else {
-                let existing = parent_table.insert(key.clone(), prev_table);
+                let existing = parent_table.insert(key, prev_table);
                 debug_assert!(existing.is_none());
             }
         } else {

--- a/crates/toml_edit/src/document.rs
+++ b/crates/toml_edit/src/document.rs
@@ -207,7 +207,7 @@ impl FromStr for DocumentMut {
 
     /// Parses a document from a &str
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let im = Document::from_str(s)?;
+        let im = Document::parse(s)?;
         Ok(im.into_mut())
     }
 }

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -33,7 +33,7 @@ pub(crate) fn encode_key(this: &Key, buf: &mut dyn Write, input: Option<&str>) -
 }
 
 fn encode_key_path(
-    this: &[Key],
+    this: &[&Key],
     mut buf: &mut dyn Write,
     input: Option<&str>,
     default_decor: (&str, &str),
@@ -214,7 +214,7 @@ impl Display for DocumentMut {
             if let Some(pos) = t.position() {
                 last_position = pos;
             }
-            tables.push((last_position, t, p.clone(), is_array));
+            tables.push((last_position, t, p.to_vec(), is_array));
             Ok(())
         })
         .unwrap();
@@ -231,12 +231,12 @@ impl Display for DocumentMut {
 
 fn visit_nested_tables<'t, F>(
     table: &'t Table,
-    path: &mut Vec<Key>,
+    path: &mut Vec<&'t Key>,
     is_array_of_tables: bool,
     callback: &mut F,
 ) -> Result
 where
-    F: FnMut(&'t Table, &Vec<Key>, bool) -> Result,
+    F: FnMut(&'t Table, &[&'t Key], bool) -> Result,
 {
     if !table.is_dotted() {
         callback(table, path, is_array_of_tables)?;
@@ -245,14 +245,12 @@ where
     for (key, value) in table.items.iter() {
         match value {
             Item::Table(t) => {
-                let key = key.clone();
                 path.push(key);
                 visit_nested_tables(t, path, false, callback)?;
                 path.pop();
             }
             Item::ArrayOfTables(a) => {
                 for t in a.iter() {
-                    let key = key.clone();
                     path.push(key);
                     visit_nested_tables(t, path, true, callback)?;
                     path.pop();
@@ -274,7 +272,7 @@ where
 ///   when the leaf decor prefix contains newlines.
 /// - `inside_header`: `&Decor` to use around the key path inside the brackets.
 fn leaf_decor_before_bracket<'a>(
-    path: &'a [Key],
+    path: &'a [&Key],
     input: Option<&str>,
 ) -> (Option<&'a Decor>, &'a Decor) {
     let Some(last_key) = path.last() else {
@@ -297,7 +295,7 @@ fn visit_table(
     mut buf: &mut dyn Write,
     input: Option<&str>,
     table: &Table,
-    path: &[Key],
+    path: &[&Key],
     is_array_of_tables: bool,
     first_table: &mut bool,
 ) -> Result {

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -32,44 +32,13 @@ pub(crate) fn encode_key(this: &Key, buf: &mut dyn Write, input: Option<&str>) -
     Ok(())
 }
 
-fn encode_key_path(
+pub(crate) fn encode_key_path(
     this: &[&Key],
     mut buf: &mut dyn Write,
     input: Option<&str>,
     default_decor: (&str, &str),
     leaf_decor: &Decor,
 ) -> Result {
-    for (i, key) in this.iter().enumerate() {
-        let dotted_decor = key.dotted_decor();
-
-        let first = i == 0;
-        let last = i + 1 == this.len();
-
-        if first {
-            leaf_decor.prefix_encode(buf, input, default_decor.0)?;
-        } else {
-            buf.key_sep()?;
-            dotted_decor.prefix_encode(buf, input, DEFAULT_KEY_PATH_DECOR.0)?;
-        }
-
-        encode_key(key, buf, input)?;
-
-        if last {
-            leaf_decor.suffix_encode(buf, input, default_decor.1)?;
-        } else {
-            dotted_decor.suffix_encode(buf, input, DEFAULT_KEY_PATH_DECOR.1)?;
-        }
-    }
-    Ok(())
-}
-
-pub(crate) fn encode_key_path_ref(
-    this: &[&Key],
-    mut buf: &mut dyn Write,
-    input: Option<&str>,
-    default_decor: (&str, &str),
-) -> Result {
-    let leaf_decor = this.last().expect("always at least one key").leaf_decor();
     for (i, key) in this.iter().enumerate() {
         let dotted_decor = key.dotted_decor();
 
@@ -170,7 +139,11 @@ pub(crate) fn encode_table(
         } else {
             DEFAULT_VALUE_DECOR
         };
-        encode_key_path_ref(&key_path, buf, input, DEFAULT_INLINE_KEY_DECOR)?;
+        let leaf_decor = key_path
+            .last()
+            .expect("always at least one key")
+            .leaf_decor();
+        encode_key_path(&key_path, buf, input, DEFAULT_INLINE_KEY_DECOR, leaf_decor)?;
         buf.keyval_sep()?;
         encode_value(value, buf, input, inner_decor)?;
     }
@@ -353,7 +326,11 @@ fn visit_table(
     }
     // print table body
     for (key_path, value) in children {
-        encode_key_path_ref(&key_path, buf, input, DEFAULT_KEY_DECOR)?;
+        let leaf_decor = key_path
+            .last()
+            .expect("always at least one key")
+            .leaf_decor();
+        encode_key_path(&key_path, buf, input, DEFAULT_KEY_DECOR, leaf_decor)?;
         buf.keyval_sep()?;
         encode_value(value, buf, input, DEFAULT_VALUE_DECOR)?;
         writeln!(buf)?;

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -26,7 +26,7 @@ pub(crate) fn encode_key(this: &Key, buf: &mut dyn Write, input: Option<&str>) -
         repr.encode(buf, input)?;
     } else {
         let repr = this.display_repr();
-        write!(buf, "{repr}")?;
+        buf.write_str(&repr)?;
     };
 
     Ok(())
@@ -80,7 +80,7 @@ pub(crate) fn encode_formatted<T: ValueRepr>(
         repr.encode(buf, input)?;
     } else {
         let repr = this.display_repr();
-        write!(buf, "{repr}")?;
+        buf.write_str(&repr)?;
     };
 
     decor.suffix_encode(buf, input, default_decor.1)?;

--- a/crates/toml_edit/src/key.rs
+++ b/crates/toml_edit/src/key.rs
@@ -103,9 +103,7 @@ impl Key {
         self.as_repr()
             .and_then(|r| r.as_raw().as_str())
             .map(Cow::Borrowed)
-            .unwrap_or_else(|| {
-                Cow::Owned(self.default_repr().as_raw().as_str().unwrap().to_owned())
-            })
+            .unwrap_or_else(|| Cow::Owned(self.default_repr().into_raw().into_string().unwrap()))
     }
 
     /// Returns the surrounding whitespace for the line entry

--- a/crates/toml_edit/src/parser/document.rs
+++ b/crates/toml_edit/src/parser/document.rs
@@ -346,7 +346,7 @@ impl State {
         let _scope = TraceScope::new("document::finish_table");
         let mut prev_table = std::mem::take(&mut self.current_table);
         if let Some(header) = self.current_header.take() {
-            let Some(key) = &header.key else {
+            let Some(key) = header.key else {
                 return;
             };
             prev_table.span = Some(header.span.start()..header.span.end());
@@ -363,8 +363,10 @@ impl State {
                 anstyle::AnsiColor::Blue.on_default(),
             );
             if header.is_array {
+                let key_span = get_key_span(&key).expect("all keys have spans");
                 let entry = parent_table
-                    .entry_format(key)
+                    .items
+                    .entry(key)
                     .or_insert(Item::ArrayOfTables(ArrayOfTables::new()));
                 let Some(array) = entry.as_array_of_tables_mut() else {
                     #[cfg(feature = "debug")]
@@ -372,7 +374,6 @@ impl State {
                         "is_array_of_tables=false",
                         anstyle::AnsiColor::Red.on_default(),
                     );
-                    let key_span = get_key_span(key).expect("all keys have spans");
                     let old_span = entry.span().unwrap_or_default();
                     let old_span = toml_parser::Span::new_unchecked(old_span.start, old_span.end);
                     errors.report_error(
@@ -393,7 +394,7 @@ impl State {
                 };
                 array.span = span;
             } else {
-                let existing = parent_table.insert_formatted(key, Item::Table(prev_table));
+                let existing = parent_table.items.insert(key, Item::Table(prev_table));
                 debug_assert!(existing.is_none());
             }
         } else {

--- a/crates/toml_edit/src/raw_string.rs
+++ b/crates/toml_edit/src/raw_string.rs
@@ -95,7 +95,7 @@ impl RawString {
     pub(crate) fn encode(&self, buf: &mut dyn std::fmt::Write, input: &str) -> std::fmt::Result {
         let raw = self.to_str(input);
         for part in raw.split('\r') {
-            write!(buf, "{part}")?;
+            buf.write_str(part)?;
         }
         Ok(())
     }
@@ -109,7 +109,7 @@ impl RawString {
     ) -> std::fmt::Result {
         let raw = self.to_str_with_default(input, default);
         for part in raw.split('\r') {
-            write!(buf, "{part}")?;
+            buf.write_str(part)?;
         }
         Ok(())
     }

--- a/crates/toml_edit/src/raw_string.rs
+++ b/crates/toml_edit/src/raw_string.rs
@@ -25,6 +25,15 @@ impl RawString {
         }
     }
 
+    #[cfg(feature = "display")]
+    pub(crate) fn into_string(self) -> Option<String> {
+        match self.0 {
+            RawStringInner::Empty => Some(String::new()),
+            RawStringInner::Explicit(s) => Some(s),
+            RawStringInner::Spanned(_) => None,
+        }
+    }
+
     /// The location within the original document
     ///
     /// This generally requires a [`Document`][crate::Document].

--- a/crates/toml_edit/src/repr.rs
+++ b/crates/toml_edit/src/repr.rs
@@ -56,9 +56,7 @@ where
         self.as_repr()
             .and_then(|r| r.as_raw().as_str())
             .map(Cow::Borrowed)
-            .unwrap_or_else(|| {
-                Cow::Owned(self.default_repr().as_raw().as_str().unwrap().to_owned())
-            })
+            .unwrap_or_else(|| Cow::Owned(self.default_repr().into_raw().into_string().unwrap()))
     }
 
     /// The location within the original document
@@ -151,6 +149,11 @@ impl Repr {
     /// Access the underlying value
     pub fn as_raw(&self) -> &RawString {
         &self.raw_value
+    }
+
+    #[cfg(feature = "display")]
+    pub(crate) fn into_raw(self) -> RawString {
+        self.raw_value
     }
 
     /// The location within the original document

--- a/crates/toml_edit/src/repr.rs
+++ b/crates/toml_edit/src/repr.rs
@@ -224,7 +224,7 @@ impl Decor {
         if let Some(prefix) = self.prefix() {
             prefix.encode_with_default(buf, input, default)
         } else {
-            write!(buf, "{default}")
+            buf.write_str(default)
         }
     }
 
@@ -248,7 +248,7 @@ impl Decor {
         if let Some(suffix) = self.suffix() {
             suffix.encode_with_default(buf, input, default)
         } else {
-            write!(buf, "{default}")
+            buf.write_str(default)
         }
     }
 

--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -488,7 +488,11 @@ impl std::fmt::Display for Table {
         let children = self.get_values();
         // print table body
         for (key_path, value) in children {
-            crate::encode::encode_key_path_ref(&key_path, f, None, DEFAULT_KEY_DECOR)?;
+            let leaf_decor = key_path
+                .last()
+                .expect("always at least one key")
+                .leaf_decor();
+            crate::encode::encode_key_path(&key_path, f, None, DEFAULT_KEY_DECOR, leaf_decor)?;
             write!(f, "=")?;
             crate::encode::encode_value(value, f, None, DEFAULT_VALUE_DECOR)?;
             writeln!(f)?;

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -59,6 +59,78 @@ impl Test {
 }
 
 #[test]
+fn parsed_document_outlives_input() {
+    let input = r#"# leading comment
+[ parent . 'child' ] # header
+value = { dotted . key = [ 1, 2, ], other = 'text' } # value
+
+[[ parent . 'entries' ]] # first
+name = "first"
+
+[[ parent . 'entries' ]] # second
+name = "second"
+# trailing comment
+"#;
+    let mut document = {
+        let owned = input.to_owned();
+        owned.parse::<DocumentMut>().unwrap()
+    };
+    assert_eq!(document.to_string(), input);
+
+    let name = document["parent"]["entries"][1]["name"]
+        .as_value_mut()
+        .unwrap();
+    let decor = name.decor().clone();
+    *name = Value::from("updated");
+    *name.decor_mut() = decor;
+    assert_eq!(
+        document.to_string(),
+        input.replace("\"second\"", "\"updated\"")
+    );
+}
+
+#[test]
+fn parse_error_outlives_input() {
+    let error = {
+        let input = String::from("[table]\nkey = 1\n[table]\nkey = 2\n");
+        input.parse::<DocumentMut>().unwrap_err()
+    };
+    assert_eq!(error.message(), "duplicate key");
+    assert!(error.to_string().contains("[table]"));
+}
+
+#[test]
+fn document_display_propagates_write_errors() {
+    use std::fmt::Write as _;
+
+    struct LimitedWriter(usize);
+
+    impl std::fmt::Write for LimitedWriter {
+        fn write_str(&mut self, s: &str) -> std::fmt::Result {
+            if s.len() > self.0 {
+                return Err(std::fmt::Error);
+            }
+            self.0 -= s.len();
+            Ok(())
+        }
+    }
+
+    let mut document = "# comment\r\n[table]\r\nvalue = { dotted.key = [1, 2] }\r\n"
+        .parse::<DocumentMut>()
+        .unwrap();
+    document["table"]["new key"] = value("new value");
+    let output = document.to_string();
+    assert!(!output.contains('\r'));
+    for limit in 0..output.len() {
+        let mut writer = LimitedWriter(limit);
+        assert!(write!(&mut writer, "{document}").is_err(), "{limit}");
+    }
+    let mut writer = LimitedWriter(output.len());
+    write!(&mut writer, "{document}").unwrap();
+    assert_eq!(writer.0, 0);
+}
+
+#[test]
 fn assign_whitespace() {
     let input = r#"
  # top comment


### PR DESCRIPTION
Some rather modest changes aimed at performance.  parse time doesnt really change, but I see dump time improve by 30-40%

---

Borrow input and move completed header keys when parsing documents. Borrow header keys when dumping, move generated representations, and write existing strings directly to avoid copies and formatting overhead.

Add dump and edit-roundtrip benchmarks with allocation profiling, plus regression coverage for input ownership and write errors.