### PR TITLE
perf: remove more allocations in dumping

### DIFF
--- a/crates/benchmarks/benches/3-keys.rs
+++ b/crates/benchmarks/benches/3-keys.rs
@@ -7,6 +7,8 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 const NUM_ENTRIES: &[usize] = &[10, 100];
 
 mod toml_edit {
+    use std::fmt::Write as _;
+
     use crate::NUM_ENTRIES;
 
     #[divan::bench(args = NUM_ENTRIES)]
@@ -26,6 +28,30 @@ mod toml_edit {
             };
             document.insert(&key, ::toml_edit::Item::Value(value));
         }
+        bencher.bench(|| std::hint::black_box(&document).to_string());
+    }
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn dotted_dump(bencher: divan::Bencher, entries: usize) {
+        let mut input = String::new();
+        for i in 0..entries {
+            writeln!(&mut input, "parent.child.key_{i} = {i}").unwrap();
+        }
+        let document = input.parse::<::toml_edit::DocumentMut>().unwrap();
+        bencher.bench(|| std::hint::black_box(&document).to_string());
+    }
+
+    #[divan::bench(args = NUM_ENTRIES)]
+    fn inline_dump(bencher: divan::Bencher, entries: usize) {
+        let mut input = String::from("value = { ");
+        for i in 0..entries {
+            if i != 0 {
+                input.push_str(", ");
+            }
+            write!(&mut input, "parent.child.key_{i} = {i}").unwrap();
+        }
+        input.push_str(" }\n");
+        let document = input.parse::<::toml_edit::DocumentMut>().unwrap();
         bencher.bench(|| std::hint::black_box(&document).to_string());
     }
 }

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -32,18 +32,38 @@ pub(crate) fn encode_key(this: &Key, buf: &mut dyn Write, input: Option<&str>) -
     Ok(())
 }
 
-pub(crate) fn encode_key_path(
+fn encode_key_path(
     this: &[&Key],
+    buf: &mut dyn Write,
+    input: Option<&str>,
+    default_decor: (&str, &str),
+    leaf_decor: &Decor,
+) -> Result {
+    let (leaf, prefix) = this.split_last().expect("always at least one key");
+    encode_key_path_parts(
+        prefix.iter().copied(),
+        leaf,
+        buf,
+        input,
+        default_decor,
+        leaf_decor,
+    )
+}
+
+fn encode_key_path_parts<'k>(
+    prefix: impl ExactSizeIterator<Item = &'k Key>,
+    leaf: &'k Key,
     mut buf: &mut dyn Write,
     input: Option<&str>,
     default_decor: (&str, &str),
     leaf_decor: &Decor,
 ) -> Result {
-    for (i, key) in this.iter().enumerate() {
+    let leaf_index = prefix.len();
+    for (i, key) in prefix.chain(std::iter::once(leaf)).enumerate() {
         let dotted_decor = key.dotted_decor();
 
         let first = i == 0;
-        let last = i + 1 == this.len();
+        let last = i == leaf_index;
 
         if first {
             leaf_decor.prefix_encode(buf, input, default_decor.0)?;

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -324,7 +324,18 @@ fn visit_table(
         table.decor.suffix_encode(buf, input, default_decor.1)?;
         writeln!(buf)?;
     }
-    // print table body
+    encode_table_values(children, buf, input)
+}
+
+pub(crate) fn encode_table_body(table: &Table, buf: &mut dyn Write, input: Option<&str>) -> Result {
+    encode_table_values(table.get_values(), buf, input)
+}
+
+fn encode_table_values(
+    children: Vec<(Vec<&Key>, &Value)>,
+    mut buf: &mut dyn Write,
+    input: Option<&str>,
+) -> Result {
     for (key_path, value) in children {
         let leaf_decor = key_path
             .last()

--- a/crates/toml_edit/src/encode.rs
+++ b/crates/toml_edit/src/encode.rs
@@ -11,6 +11,7 @@ use crate::key::Key;
 use crate::repr::{Decor, Formatted, Repr, ValueRepr};
 use crate::table::{
     DEFAULT_KEY_DECOR, DEFAULT_KEY_PATH_DECOR, DEFAULT_ROOT_DECOR, DEFAULT_TABLE_DECOR,
+    ValueEntries,
 };
 use crate::value::{
     DEFAULT_LEADING_VALUE_DECOR, DEFAULT_TRAILING_VALUE_DECOR, DEFAULT_VALUE_DECOR,
@@ -148,23 +149,30 @@ pub(crate) fn encode_table(
     decor.prefix_encode(buf, input, default_decor.0)?;
     buf.open_inline_table()?;
 
-    let children = this.get_values();
-    let len = children.len();
-    for (i, (key_path, value)) in children.into_iter().enumerate() {
-        if i != 0 {
+    let mut children = this.iter_values();
+    let mut first = true;
+    loop {
+        let Some((prefix, key, value)) = children.next() else {
+            break;
+        };
+        if !first {
             buf.val_sep()?;
         }
-        let inner_decor = if i == len - 1 {
+        first = false;
+        encode_key_path_parts(
+            prefix,
+            key,
+            buf,
+            input,
+            DEFAULT_INLINE_KEY_DECOR,
+            key.leaf_decor(),
+        )?;
+        buf.keyval_sep()?;
+        let inner_decor = if children.peek().is_none() {
             DEFAULT_TRAILING_VALUE_DECOR
         } else {
             DEFAULT_VALUE_DECOR
         };
-        let leaf_decor = key_path
-            .last()
-            .expect("always at least one key")
-            .leaf_decor();
-        encode_key_path(&key_path, buf, input, DEFAULT_INLINE_KEY_DECOR, leaf_decor)?;
-        buf.keyval_sep()?;
         encode_value(value, buf, input, inner_decor)?;
     }
     if this.trailing_comma() && !this.is_empty() {
@@ -292,7 +300,8 @@ fn visit_table(
     is_array_of_tables: bool,
     first_table: &mut bool,
 ) -> Result {
-    let children = table.get_values();
+    let mut children = table.iter_values();
+    let has_values = children.peek().is_some();
     // We are intentionally hiding implicit tables without any tables nested under them (ie
     // `table.is_empty()` which is in contrast to `table.get_values().is_empty()`).  We are
     // trusting the user that an empty implicit table is not semantically meaningful
@@ -302,11 +311,11 @@ fn visit_table(
     //
     // However, this means that users need to take care in deciding what tables get marked as
     // implicit.
-    let is_visible_std_table = !(table.implicit && children.is_empty());
+    let is_visible_std_table = !(table.implicit && !has_values);
 
     if path.is_empty() {
         // don't print header for the root node
-        if !children.is_empty() {
+        if has_values {
             *first_table = false;
         }
     } else if is_array_of_tables {
@@ -344,24 +353,20 @@ fn visit_table(
         table.decor.suffix_encode(buf, input, default_decor.1)?;
         writeln!(buf)?;
     }
-    encode_table_values(children, buf, input)
+    encode_table_values(&mut children, buf, input)
 }
 
 pub(crate) fn encode_table_body(table: &Table, buf: &mut dyn Write, input: Option<&str>) -> Result {
-    encode_table_values(table.get_values(), buf, input)
+    encode_table_values(&mut table.iter_values(), buf, input)
 }
 
 fn encode_table_values(
-    children: Vec<(Vec<&Key>, &Value)>,
+    children: &mut ValueEntries<'_>,
     mut buf: &mut dyn Write,
     input: Option<&str>,
 ) -> Result {
-    for (key_path, value) in children {
-        let leaf_decor = key_path
-            .last()
-            .expect("always at least one key")
-            .leaf_decor();
-        encode_key_path(&key_path, buf, input, DEFAULT_KEY_DECOR, leaf_decor)?;
+    while let Some((prefix, key, value)) = children.next() {
+        encode_key_path_parts(prefix, key, buf, input, DEFAULT_KEY_DECOR, key.leaf_decor())?;
         buf.keyval_sep()?;
         encode_value(value, buf, input, DEFAULT_VALUE_DECOR)?;
         writeln!(buf)?;

--- a/crates/toml_edit/src/inline_table.rs
+++ b/crates/toml_edit/src/inline_table.rs
@@ -2,7 +2,7 @@ use std::iter::FromIterator;
 
 use crate::key::Key;
 use crate::repr::Decor;
-use crate::table::{Iter, IterMut, KeyValuePairs, TableLike};
+use crate::table::{Iter, IterMut, KeyValuePairs, TableLike, ValueEntries};
 use crate::{Item, KeyMut, RawString, Table, Value};
 
 /// A TOML [`Value`] that contains a collection of [`Key`]/[`Value`] pairs
@@ -52,37 +52,11 @@ impl InlineTable {
     ///
     /// For example, this will return dotted keys
     pub fn get_values(&self) -> Vec<(Vec<&Key>, &Value)> {
-        let mut values = Vec::new();
-        let mut root = Vec::new();
-        self.append_values(&mut root, &mut values);
-        values
+        self.iter_values().into_vec()
     }
 
-    /// Helper for `get_values()`.
-    ///
-    /// `path` is the parent for this table. path is mutable to reuse allocations but no mutations
-    /// should be observable.
-    pub(crate) fn append_values<'s>(
-        &'s self,
-        path: &mut Vec<&'s Key>,
-        values: &mut Vec<(Vec<&'s Key>, &'s Value)>,
-    ) {
-        for (key, value) in self.items.iter() {
-            path.push(key);
-            match value {
-                Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
-                    table.append_values(path, values);
-                }
-                Item::Value(value) => {
-                    values.push((path.clone(), value));
-                }
-                Item::Table(table) => {
-                    table.append_all_values(path, values);
-                }
-                _ => {}
-            }
-            path.pop();
-        }
+    pub(crate) fn iter_values(&self) -> ValueEntries<'_> {
+        ValueEntries::new(&self.items, true)
     }
 
     /// Auto formats the table.

--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -64,74 +64,11 @@ impl Table {
     ///
     /// For example, this will return dotted keys
     pub fn get_values(&self) -> Vec<(Vec<&Key>, &Value)> {
-        let mut values = Vec::new();
-        let mut root = Vec::new();
-        self.append_values(&mut root, &mut values);
-        values
+        self.iter_values().into_vec()
     }
 
-    /// Helper for `get_values()`.
-    ///
-    /// `path` is the parent for this table. path is mutable to reuse allocations but no mutations
-    /// should be observable.
-    fn append_values<'s>(
-        &'s self,
-        path: &mut Vec<&'s Key>,
-        values: &mut Vec<(Vec<&'s Key>, &'s Value)>,
-    ) {
-        for (key, value) in self.items.iter() {
-            path.push(key);
-            match value {
-                Item::Table(table) if table.is_dotted() => {
-                    table.append_values(path, values);
-                }
-                Item::Value(value) => {
-                    if let Some(table) = value.as_inline_table() {
-                        if table.is_dotted() {
-                            table.append_values(path, values);
-                        } else {
-                            values.push((path.clone(), value));
-                        }
-                    } else {
-                        values.push((path.clone(), value));
-                    }
-                }
-                _ => {}
-            }
-            path.pop();
-        }
-    }
-
-    /// Helper for `get_values()`.
-    ///
-    /// `path` is the parent for this table. path is mutable to reuse allocations but no mutations
-    /// should be observable.
-    pub(crate) fn append_all_values<'s>(
-        &'s self,
-        path: &mut Vec<&'s Key>,
-        values: &mut Vec<(Vec<&'s Key>, &'s Value)>,
-    ) {
-        for (key, value) in self.items.iter() {
-            path.push(key);
-            match value {
-                Item::Table(table) => {
-                    table.append_all_values(path, values);
-                }
-                Item::Value(value) => {
-                    if let Some(table) = value.as_inline_table() {
-                        if table.is_dotted() {
-                            table.append_values(path, values);
-                        } else {
-                            values.push((path.clone(), value));
-                        }
-                    } else {
-                        values.push((path.clone(), value));
-                    }
-                }
-                _ => {}
-            }
-            path.pop();
-        }
+    pub(crate) fn iter_values(&self) -> ValueEntries<'_> {
+        ValueEntries::new(&self.items, false)
     }
 
     /// Auto formats the table.
@@ -529,6 +466,103 @@ impl<'s> IntoIterator for &'s Table {
 
 pub(crate) type KeyValuePairs = IndexMap<Key, Item>;
 
+/// Visual key/value traversal. Only nested key paths require stack storage.
+///
+/// Entries borrow their key-path prefix from the cursor, so the path must be
+/// consumed before advancing with either `next()` or `peek()`.
+pub(crate) struct ValueEntries<'a> {
+    current: ValueEntriesFrame<'a>,
+    parents: Vec<ValueEntriesParent<'a>>,
+    // When cached, the traversal is already positioned at this value's path.
+    peeked: Option<(&'a Key, &'a Value)>,
+}
+
+struct ValueEntriesFrame<'a> {
+    items: indexmap::map::Iter<'a, Key, Item>,
+    // Dotted tables are always flattened; inline-table bodies also flatten
+    // ordinary table descendants.
+    flatten_all_tables: bool,
+}
+
+struct ValueEntriesParent<'a> {
+    frame: ValueEntriesFrame<'a>,
+    key: &'a Key,
+}
+
+impl<'a> ValueEntries<'a> {
+    pub(crate) fn new(items: &'a KeyValuePairs, flatten_all_tables: bool) -> Self {
+        Self {
+            current: ValueEntriesFrame {
+                items: items.iter(),
+                flatten_all_tables,
+            },
+            parents: Vec::new(),
+            peeked: None,
+        }
+    }
+
+    pub(crate) fn next(
+        &mut self,
+    ) -> Option<(
+        impl ExactSizeIterator<Item = &'a Key> + '_,
+        &'a Key,
+        &'a Value,
+    )> {
+        let (key, value) = self.peeked.take().or_else(|| self.advance())?;
+        let prefix = self.parents.iter().map(|parent| parent.key);
+        Some((prefix, key, value))
+    }
+
+    #[cfg(feature = "display")]
+    pub(crate) fn peek(&mut self) -> Option<(&'a Key, &'a Value)> {
+        if self.peeked.is_none() {
+            self.peeked = self.advance();
+        }
+        self.peeked
+    }
+
+    pub(crate) fn into_vec(mut self) -> Vec<(Vec<&'a Key>, &'a Value)> {
+        let mut values = Vec::new();
+        while let Some((prefix, key, value)) = self.next() {
+            let path = prefix.chain(std::iter::once(key)).collect();
+            values.push((path, value));
+        }
+        values
+    }
+
+    fn advance(&mut self) -> Option<(&'a Key, &'a Value)> {
+        loop {
+            let Some((key, item)) = self.current.items.next() else {
+                self.current = self.parents.pop()?.frame;
+                continue;
+            };
+
+            match item {
+                Item::Table(table) if self.current.flatten_all_tables || table.is_dotted() => {
+                    self.descend(key, &table.items, self.current.flatten_all_tables);
+                }
+                Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
+                    self.descend(key, &table.items, true);
+                }
+                Item::Value(value) => return Some((key, value)),
+                _ => {}
+            }
+        }
+    }
+
+    fn descend(&mut self, key: &'a Key, items: &'a KeyValuePairs, flatten_all_tables: bool) {
+        let child = ValueEntriesFrame {
+            items: items.iter(),
+            flatten_all_tables,
+        };
+        // The saved iterator has consumed this child and will resume at its sibling.
+        self.parents.push(ValueEntriesParent {
+            frame: std::mem::replace(&mut self.current, child),
+            key,
+        });
+    }
+}
+
 fn decorate_table(table: &mut Table) {
     use indexmap::map::MutableKeys;
     for (mut key, value) in table
@@ -808,5 +842,214 @@ impl<'a> VacantEntry<'a> {
     pub fn insert(self, value: Item) -> &'a mut Item {
         let entry = self.entry;
         entry.insert(value)
+    }
+}
+
+#[cfg(all(test, feature = "display"))]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+
+    type VisualValues<'a> = Vec<(Vec<&'a Key>, &'a Value)>;
+    type EntryIdentity = (Vec<*const Key>, *const Value);
+
+    fn pairs(items: Vec<Item>) -> KeyValuePairs {
+        items
+            .into_iter()
+            .enumerate()
+            .map(|(i, item)| (Key::new(format!("key_{i}")), item))
+            .collect()
+    }
+
+    fn arbitrary_item() -> BoxedStrategy<Item> {
+        let array = crate::Array::from_iter([1, 2]);
+        let mut tables = crate::ArrayOfTables::new();
+        tables.push(Table::with_pairs(pairs(vec![crate::value(3)])));
+        let leaf = prop_oneof![
+            Just(Item::None),
+            any::<i64>().prop_map(|value| Item::Value(value.into())),
+            any::<bool>().prop_map(|value| Item::Value(value.into())),
+            Just(Item::Value(crate::Array::new().into())),
+            Just(Item::ArrayOfTables(crate::ArrayOfTables::new())),
+            Just(Item::Value(array.into())),
+            Just(Item::ArrayOfTables(tables)),
+        ];
+        leaf.prop_recursive(8, 128, 4, |inner| {
+            (
+                prop::collection::vec(inner, 0..5),
+                any::<bool>(),
+                any::<bool>(),
+                any::<bool>(),
+            )
+                .prop_map(|(items, inline, dotted, implicit)| {
+                    if inline {
+                        let mut table = InlineTable::with_pairs(pairs(items));
+                        table.set_dotted(dotted);
+                        table.set_implicit(implicit);
+                        Item::Value(table.into())
+                    } else {
+                        let mut table = Table::with_pairs(pairs(items));
+                        table.set_dotted(dotted);
+                        table.set_implicit(implicit);
+                        Item::Table(table)
+                    }
+                })
+        })
+        .boxed()
+    }
+
+    fn identities(values: &VisualValues<'_>) -> Vec<EntryIdentity> {
+        values
+            .iter()
+            .map(|(path, value)| {
+                (
+                    path.iter().map(|key| std::ptr::from_ref(*key)).collect(),
+                    std::ptr::from_ref(*value),
+                )
+            })
+            .collect()
+    }
+
+    fn check_cursor(
+        mut cursor: ValueEntries<'_>,
+        expected: &VisualValues<'_>,
+        peek_counts: &[u8],
+    ) -> Result<(), TestCaseError> {
+        let mut actual = Vec::new();
+        for i in 0..=expected.len() {
+            let expected_entry = expected.get(i).map(|(path, value)| {
+                (
+                    std::ptr::from_ref(*path.last().unwrap()),
+                    std::ptr::from_ref(*value),
+                )
+            });
+            for _ in 0..peek_counts[i % peek_counts.len()] {
+                let peeked = cursor
+                    .peek()
+                    .map(|(key, value)| (std::ptr::from_ref(key), std::ptr::from_ref(value)));
+                prop_assert_eq!(peeked, expected_entry);
+            }
+            let entry = cursor
+                .next()
+                .map(|(prefix, key, value)| (prefix.chain(std::iter::once(key)).collect(), value));
+            prop_assert_eq!(entry.is_some(), expected_entry.is_some());
+            if let Some(entry) = entry {
+                actual.push(entry);
+            }
+        }
+        prop_assert_eq!(identities(&actual), identities(expected));
+        prop_assert!(cursor.peek().is_none());
+        prop_assert!(cursor.peek().is_none());
+        prop_assert!(cursor.next().is_none());
+        Ok(())
+    }
+
+    // Preserve the previous recursive traversal as an independent reference.
+    fn reference_table<'a>(
+        table: &'a Table,
+        path: &mut Vec<&'a Key>,
+        values: &mut VisualValues<'a>,
+    ) {
+        for (key, item) in &table.items {
+            path.push(key);
+            match item {
+                Item::Table(table) if table.is_dotted() => {
+                    reference_table(table, path, values);
+                }
+                Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
+                    reference_inline(table, path, values);
+                }
+                Item::Value(value) => values.push((path.clone(), value)),
+                _ => {}
+            }
+            path.pop();
+        }
+    }
+
+    fn reference_inline<'a>(
+        table: &'a InlineTable,
+        path: &mut Vec<&'a Key>,
+        values: &mut VisualValues<'a>,
+    ) {
+        for (key, item) in &table.items {
+            path.push(key);
+            match item {
+                Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
+                    reference_inline(table, path, values);
+                }
+                Item::Value(value) => values.push((path.clone(), value)),
+                Item::Table(table) => reference_all_values(table, path, values),
+                _ => {}
+            }
+            path.pop();
+        }
+    }
+
+    fn reference_all_values<'a>(
+        table: &'a Table,
+        path: &mut Vec<&'a Key>,
+        values: &mut VisualValues<'a>,
+    ) {
+        for (key, item) in &table.items {
+            path.push(key);
+            match item {
+                Item::Table(table) => reference_all_values(table, path, values),
+                Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
+                    reference_inline(table, path, values);
+                }
+                Item::Value(value) => values.push((path.clone(), value)),
+                _ => {}
+            }
+            path.pop();
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: 512,
+            ..ProptestConfig::default()
+        })]
+
+        #[test]
+        fn visual_values_match_reference(
+            items in prop::collection::vec(arbitrary_item(), 0..5),
+            peek_counts in prop::collection::vec(0u8..4, 1..8),
+        ) {
+            let items = pairs(items);
+            let table = Table::with_pairs(items.clone());
+            let inline = InlineTable::with_pairs(items);
+
+            let mut expected = Vec::new();
+            reference_table(&table, &mut Vec::new(), &mut expected);
+            prop_assert_eq!(identities(&table.get_values()), identities(&expected));
+            check_cursor(table.iter_values(), &expected, &peek_counts)?;
+
+            let mut expected = Vec::new();
+            reference_inline(&inline, &mut Vec::new(), &mut expected);
+            prop_assert_eq!(identities(&inline.get_values()), identities(&expected));
+            check_cursor(inline.iter_values(), &expected, &peek_counts)?;
+        }
+    }
+
+    #[test]
+    fn visual_values_restore_deep_mixed_paths() {
+        let mut item = crate::value(42);
+        for depth in 0..12 {
+            let items = pairs(vec![Item::None, item, crate::value(depth), Item::None]);
+            item = if depth % 2 == 0 {
+                Item::Table(Table::with_pairs(items))
+            } else {
+                let mut table = InlineTable::with_pairs(items);
+                table.set_dotted(true);
+                Item::Value(table.into())
+            };
+        }
+        let hidden = Table::with_pairs(pairs(vec![crate::value(99)]));
+        let table = Table::with_pairs(pairs(vec![item, Item::Table(hidden), crate::value(0)]));
+        let mut expected = Vec::new();
+        reference_table(&table, &mut Vec::new(), &mut expected);
+        assert_eq!(expected.len(), 14);
+        assert_eq!(identities(&table.get_values()), identities(&expected));
+        check_cursor(table.iter_values(), &expected, &[0, 1, 2, 3]).unwrap();
     }
 }

--- a/crates/toml_edit/src/table.rs
+++ b/crates/toml_edit/src/table.rs
@@ -4,7 +4,6 @@ use indexmap::map::IndexMap;
 
 use crate::key::Key;
 use crate::repr::Decor;
-use crate::value::DEFAULT_VALUE_DECOR;
 use crate::{InlineTable, Item, KeyMut, Value};
 
 /// A TOML table, a top-level collection of key/[`Value`] pairs under a header and logical
@@ -485,19 +484,7 @@ impl Table {
 #[cfg(feature = "display")]
 impl std::fmt::Display for Table {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let children = self.get_values();
-        // print table body
-        for (key_path, value) in children {
-            let leaf_decor = key_path
-                .last()
-                .expect("always at least one key")
-                .leaf_decor();
-            crate::encode::encode_key_path(&key_path, f, None, DEFAULT_KEY_DECOR, leaf_decor)?;
-            write!(f, "=")?;
-            crate::encode::encode_value(value, f, None, DEFAULT_VALUE_DECOR)?;
-            writeln!(f)?;
-        }
-        Ok(())
+        crate::encode::encode_table_body(self, f, None)
     }
 }
 

--- a/crates/toml_edit/tests/testsuite/edit.rs
+++ b/crates/toml_edit/tests/testsuite/edit.rs
@@ -3,7 +3,9 @@ use std::iter::FromIterator;
 use snapbox::assert_data_eq;
 use snapbox::prelude::*;
 use snapbox::str;
-use toml_edit::{DocumentMut, Item, Key, Table, Value, array, table, value};
+use toml_edit::{
+    DocumentMut, InlineTable, Item, Key, Table, TableLike, Value, array, table, value,
+};
 
 macro_rules! parse_key {
     ($s:expr) => {{
@@ -128,6 +130,113 @@ fn document_display_propagates_write_errors() {
     let mut writer = LimitedWriter(output.len());
     write!(&mut writer, "{document}").unwrap();
     assert_eq!(writer.0, 0);
+}
+
+#[test]
+fn visual_values_skip_empty_and_standard_tables() {
+    let table = table_with_hidden_values();
+    assert_eq!(
+        table.to_string(),
+        "first.a = 1
+second.b = 2
+plain = 3
+"
+    );
+}
+
+#[test]
+fn get_values_skips_empty_and_standard_tables() {
+    let table = table_with_hidden_values();
+    let values = table.get_values();
+    assert_eq!(values.len(), 3);
+    assert_eq!(values[0].0, ["first", "a"]);
+    assert_eq!(values[0].1.as_integer(), Some(1));
+    assert_eq!(values[1].0, ["second", "b"]);
+    assert_eq!(values[1].1.as_integer(), Some(2));
+    assert_eq!(values[2].0, ["plain"]);
+    assert_eq!(values[2].1.as_integer(), Some(3));
+}
+
+fn table_with_hidden_values() -> Table {
+    let input = "first.a = 1
+second.b = 2
+plain = 3
+";
+    let mut table = input.parse::<DocumentMut>().unwrap().into_table();
+    let mut empty = Table::new();
+    empty.set_dotted(true);
+    table.insert("empty", Item::Table(empty));
+    table.insert("none", Item::None);
+    let mut nested = Table::new();
+    nested.insert("not_in_body", value(4));
+    table.insert("header_only", Item::Table(nested));
+    table
+}
+
+#[test]
+fn inline_table_last_visible_value() {
+    let mut table = inline_table_with_hidden_values();
+    assert_eq!(table.to_string(), "{ a = 1 }");
+
+    table.set_trailing_comma(true);
+    table.set_trailing(" ");
+    assert_eq!(table.to_string(), "{ a = 1 , }");
+    table.get_mut("a").unwrap().decor_mut().set_suffix("");
+    assert_eq!(table.to_string(), "{ a = 1, }");
+
+    table.remove("a");
+    table.set_trailing_comma(false);
+    table.set_trailing("");
+    assert_eq!(table.to_string(), "{}");
+}
+
+#[test]
+fn inline_get_values_skips_empty_tables_and_placeholders() {
+    let mut table = inline_table_with_hidden_values();
+    let values = table.get_values();
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0].0, ["a"]);
+    assert_eq!(values[0].1.as_integer(), Some(1));
+    table.remove("a");
+    assert!(table.get_values().is_empty());
+}
+
+fn inline_table_with_hidden_values() -> InlineTable {
+    let mut table = InlineTable::new();
+    table.insert("a", 1.into());
+    let mut empty = InlineTable::new();
+    empty.set_dotted(true);
+    table.insert("empty", empty.into());
+    TableLike::entry(&mut table, "none").or_insert(Item::None);
+    table
+}
+
+#[test]
+fn inline_table_flattens_standard_table_descendants() {
+    let table = inline_table_with_standard_descendants();
+    assert_eq!(table.to_string(), "{ parent.child.value = 1, last = 2 }");
+}
+
+#[test]
+fn inline_get_values_flattens_standard_table_descendants() {
+    let table = inline_table_with_standard_descendants();
+    let values = table.get_values();
+    assert_eq!(values.len(), 2);
+    assert_eq!(values[0].0, ["parent", "child", "value"]);
+    assert_eq!(values[0].1.as_integer(), Some(1));
+    assert_eq!(values[1].0, ["last"]);
+    assert_eq!(values[1].1.as_integer(), Some(2));
+}
+
+fn inline_table_with_standard_descendants() -> InlineTable {
+    let mut leaf = Table::new();
+    leaf.insert("value", value(1));
+    let mut branch = Table::new();
+    branch.insert("child", Item::Table(leaf));
+    let mut table = InlineTable::new();
+    TableLike::entry(&mut table, "parent").or_insert(Item::Table(branch));
+    table.insert("last", 2.into());
+    table
 }
 
 #[test]


### PR DESCRIPTION
This one is more intrusive than the just-merged PR, it is not so clear to me that the juice is worth the squeeze.

Idea is to replace recursive collection in `Table.get_values()` (and `InlineTable.get_values()`) with a `ValueEntries` cursor.

Commits set up:
- behaviour tests that the refactor should preserve
- benchmarks for documents that will show improvement
- preparatory refactor introducing the cursor
- use the cursor, for maybe a 15-20% win in typical documents